### PR TITLE
safe sleep for coordinator thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,10 +210,10 @@ test: | test_target/test
 	@./test_target/test
 
 test_target:
-	mkdir $@ 
+	mkdir $@
 
 test_target/obj: | test_target
-	mkdir $@ 
+	mkdir $@
 
 test_target/obj/hdr_histogram: | test_target/obj
 	mkdir $@

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -34,6 +34,20 @@
 
 #include <hdr_histogram/hdr_histogram.h>
 
+
+#ifdef _TEST
+
+// when testing, make all functions global symbols
+#define LOCAL_HELPER
+
+#else
+
+// normally local helper functions should be local symbols
+#define LOCAL_HELPER static
+
+#endif /* _TEST */
+
+
 #define _STR(x) #x
 #define STR(x) _STR(x)
 

--- a/src/include/main.h
+++ b/src/include/main.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <check.h>
+
+/*
+ * sets the fork status of the global srunner, which can be called in
+ * forked child processes in test cases so they always exit(1) instead of
+ * jumping to the failure case on failed assertions
+ */
+void set_fork_status(enum fork_status status);
+

--- a/src/main/benchmark.c
+++ b/src/main/benchmark.c
@@ -46,14 +46,14 @@
 // Forward declarations.
 //
 
-static bool as_client_log_cb(as_log_level level, const char* func,
+LOCAL_HELPER bool as_client_log_cb(as_log_level level, const char* func,
 		const char* file, uint32_t line, const char* fmt, ...);
-static int connect_to_server(args_t* args, aerospike* client);
-static bool is_single_bin(aerospike* client, const char* namespace);
-static tdata_t* init_tdata(cdata_t* cdata, thr_coord_t* coord,
+LOCAL_HELPER int connect_to_server(args_t* args, aerospike* client);
+LOCAL_HELPER bool is_single_bin(aerospike* client, const char* namespace);
+LOCAL_HELPER tdata_t* init_tdata(cdata_t* cdata, thr_coord_t* coord,
 		uint32_t t_idx);
-static void destroy_tdata(tdata_t* tdata);
-static int _run(cdata_t* cdata);
+LOCAL_HELPER void destroy_tdata(tdata_t* tdata);
+LOCAL_HELPER int _run(cdata_t* cdata);
 
 
 //==========================================================
@@ -147,7 +147,7 @@ run_benchmark(args_t* args)
 // Local helpers.
 //
 
-static bool
+LOCAL_HELPER bool
 as_client_log_cb(as_log_level level, const char* func, const char* file,
 		uint32_t line, const char* fmt, ...)
 {
@@ -159,7 +159,7 @@ as_client_log_cb(as_log_level level, const char* func, const char* file,
 	return true;
 }
 
-static int
+LOCAL_HELPER int
 connect_to_server(args_t* args, aerospike* client)
 {
 	if (stages_contain_async(&args->stages)) {
@@ -258,7 +258,7 @@ connect_to_server(args_t* args, aerospike* client)
 	return 0;
 }
 
-static bool
+LOCAL_HELPER bool
 is_single_bin(aerospike* client, const char* namespace)
 {
 	char filter[256];
@@ -298,7 +298,7 @@ is_single_bin(aerospike* client, const char* namespace)
 /*
  * allocates and initializes a new threaddata struct, returning a pointer to it
  */
-static tdata_t*
+LOCAL_HELPER tdata_t*
 init_tdata(cdata_t* cdata, thr_coord_t* coord,
 		uint32_t t_idx)
 {
@@ -317,12 +317,12 @@ init_tdata(cdata_t* cdata, thr_coord_t* coord,
 	return tdata;
 }
 
-static void
+LOCAL_HELPER void
 destroy_tdata(tdata_t* tdata)
 {
 }
 
-static int
+LOCAL_HELPER int
 _run(cdata_t* cdata)
 {
 	int ret = 0;

--- a/src/main/common.c
+++ b/src/main/common.c
@@ -36,16 +36,16 @@
 // Forward declarations.
 //
 
-static int as_bytes_cmp(as_bytes* b1, as_bytes* b2);
-static int as_list_cmp_max(const as_list* list1, const as_list* list2,
+LOCAL_HELPER int as_bytes_cmp(as_bytes* b1, as_bytes* b2);
+LOCAL_HELPER int as_list_cmp_max(const as_list* list1, const as_list* list2,
 		uint32_t max, uint32_t fin);
-static int as_list_cmp(const as_list* list1, const as_list* list2);
-static int as_vector_cmp(as_vector* list1, as_vector* list2);
-static bool key_append(const as_val* key, const as_val* val, void* udata);
-static int key_cmp(const void* v1, const void* v2);
-static bool map_to_sorted_keys(const as_map* map, uint32_t size,
+LOCAL_HELPER int as_list_cmp(const as_list* list1, const as_list* list2);
+LOCAL_HELPER int as_vector_cmp(as_vector* list1, as_vector* list2);
+LOCAL_HELPER bool key_append(const as_val* key, const as_val* val, void* udata);
+LOCAL_HELPER int key_cmp(const void* v1, const void* v2);
+LOCAL_HELPER bool map_to_sorted_keys(const as_map* map, uint32_t size,
 		as_vector* list);
-static int as_map_cmp(const as_map* map1, const as_map* map2);
+LOCAL_HELPER int as_map_cmp(const as_map* map1, const as_map* map2);
 
 
 //==========================================================
@@ -274,7 +274,7 @@ void print_hdr_percentiles(struct hdr_histogram* h, const char* name,
 // Local helpers.
 //
 
-static int
+LOCAL_HELPER int
 as_bytes_cmp(as_bytes* b1, as_bytes* b2)
 {
 	if (b1->size == b2->size) {
@@ -290,7 +290,7 @@ as_bytes_cmp(as_bytes* b1, as_bytes* b2)
 	}
 }
 
-static int
+LOCAL_HELPER int
 as_list_cmp_max(const as_list* list1, const as_list* list2, uint32_t max, uint32_t fin)
 {
 	for (uint32_t i = 0; i < max; i++) {
@@ -303,7 +303,7 @@ as_list_cmp_max(const as_list* list1, const as_list* list2, uint32_t max, uint32
 	return fin;
 }
 
-static int
+LOCAL_HELPER int
 as_list_cmp(const as_list* list1, const as_list* list2)
 {
 	uint32_t size1 = as_list_size(list1);
@@ -320,7 +320,7 @@ as_list_cmp(const as_list* list1, const as_list* list2)
 	}
 }
 
-static int
+LOCAL_HELPER int
 as_vector_cmp(as_vector* list1, as_vector* list2)
 {
 	// Size of vectors should already be the same.
@@ -334,20 +334,20 @@ as_vector_cmp(as_vector* list1, as_vector* list2)
 	return 0;
 }
 
-static bool
+LOCAL_HELPER bool
 key_append(const as_val* key, const as_val* val, void* udata)
 {
 	as_vector_append(udata, (void*)&key);
 	return true;
 }
 
-static int
+LOCAL_HELPER int
 key_cmp(const void* v1, const void* v2)
 {
 	return as_val_cmp(*(as_val**)v1, *(as_val**)v2);
 }
 
-static bool
+LOCAL_HELPER bool
 map_to_sorted_keys(const as_map* map, uint32_t size, as_vector* list)
 {
 	as_vector_init(list, sizeof(as_val*), size);
@@ -361,7 +361,7 @@ map_to_sorted_keys(const as_map* map, uint32_t size, as_vector* list)
 	return true;
 }
 
-static int
+LOCAL_HELPER int
 as_map_cmp(const as_map* map1, const as_map* map2)
 {
 	// Map ordering documented at https://www.aerospike.com/docs/guide/cdt-ordering.html

--- a/src/main/coordinator.c
+++ b/src/main/coordinator.c
@@ -205,6 +205,11 @@ _sleep_for(uint64_t n_secs)
 
 	do {
 		res = nanosleep(&sleep_time, &sleep_time);
+
+		if (res != 0) {
+			blog_info("sleep interrupted (res=%d, errno=%d (%s))\n",
+					res, errno, strerror(errno));
+		}
 	} while (res != 0 && errno == EINTR);
 
 	return res;

--- a/src/main/coordinator.c
+++ b/src/main/coordinator.c
@@ -17,16 +17,16 @@
 // Forward declarations.
 //
 
-static int _has_not_happened(const struct timespec* time);
-static int _sleep_for(uint64_t n_secs);
-static void _halt_threads(thr_coord_t* coord,
+LOCAL_HELPER int _has_not_happened(const struct timespec* time);
+LOCAL_HELPER int _sleep_for(uint64_t n_secs);
+LOCAL_HELPER void _halt_threads(thr_coord_t* coord,
 		tdata_t** tdatas, uint32_t n_threads);
-static void _terminate_threads(thr_coord_t* coord,
+LOCAL_HELPER void _terminate_threads(thr_coord_t* coord,
 		tdata_t** tdatas, uint32_t n_threads);
-static void _release_threads(thr_coord_t* coord,
+LOCAL_HELPER void _release_threads(thr_coord_t* coord,
 		tdata_t** tdatas, uint32_t n_threads);
-static void _finish_req_duration(thr_coord_t* coord);
-static void clear_cdata_counts(cdata_t* cdata);
+LOCAL_HELPER void _finish_req_duration(thr_coord_t* coord);
+LOCAL_HELPER void clear_cdata_counts(cdata_t* cdata);
 
 
 //==========================================================
@@ -180,7 +180,7 @@ coordinator_worker(void* udata)
 /*
  * checks whether the time has not passed "time" yet
  */
-static int
+LOCAL_HELPER int
 _has_not_happened(const struct timespec* time)
 {
 	struct timespec now;
@@ -194,7 +194,7 @@ _has_not_happened(const struct timespec* time)
  *
  * returns 0 if the sleep was successful, otherwise -1 if an error occured
  */
-static int
+LOCAL_HELPER int
 _sleep_for(uint64_t n_secs)
 {
 	struct timespec sleep_time;
@@ -218,7 +218,7 @@ _sleep_for(uint64_t n_secs)
 /*
  * halt all threads and return once all threads have called thr_coordinator_wait
  */
-static void
+LOCAL_HELPER void
 _halt_threads(thr_coord_t* coord,
 		tdata_t** tdatas, uint32_t n_threads)
 {
@@ -232,7 +232,7 @@ _halt_threads(thr_coord_t* coord,
  * signal to all threads to stop execution and return,
  * must be called after a call to _halt_threads
  */
-static void
+LOCAL_HELPER void
 _terminate_threads(thr_coord_t* coord,
 		tdata_t** tdatas, uint32_t n_threads)
 {
@@ -246,7 +246,7 @@ _terminate_threads(thr_coord_t* coord,
  * signal to all threads to continue execution,
  * must be called after a call to _halt_threads
  */
-static void
+LOCAL_HELPER void
 _release_threads(thr_coord_t* coord,
 		tdata_t** tdatas, uint32_t n_threads)
 {
@@ -262,7 +262,7 @@ _release_threads(thr_coord_t* coord,
  * the count of unfinished threads and wait on the condition variable until
  * all threads have finished their required tasks
  */
-static void
+LOCAL_HELPER void
 _finish_req_duration(thr_coord_t* coord)
 {
 	pthread_mutex_lock(&coord->c_lock);
@@ -295,7 +295,7 @@ _finish_req_duration(thr_coord_t* coord)
  * note: this is not thread safe, only call this when all other threads are
  * halted
  */
-static void
+LOCAL_HELPER void
 clear_cdata_counts(cdata_t* cdata)
 {
 	cdata->write_count = 0;

--- a/src/main/coordinator.c
+++ b/src/main/coordinator.c
@@ -203,9 +203,14 @@ _sleep_for(uint64_t n_secs)
 	sleep_time.tv_sec = n_secs;
 	sleep_time.tv_nsec = 0;
 
+	printf("start sleep at %lu for %lu secs\n", time(NULL), n_secs);
+
 	do {
 		res = nanosleep(&sleep_time, &sleep_time);
+		printf("sleep wake at %lu (res=%d, errno=%d (%s))\n", time(NULL), res, errno, strerror(errno));
 	} while (res != 0 && errno == EINTR);
+
+	printf("stop sleep at %lu\n", time(NULL));
 
 	return res;
 }

--- a/src/main/coordinator.c
+++ b/src/main/coordinator.c
@@ -203,14 +203,9 @@ _sleep_for(uint64_t n_secs)
 	sleep_time.tv_sec = n_secs;
 	sleep_time.tv_nsec = 0;
 
-	printf("start sleep at %lu for %lu secs\n", time(NULL), n_secs);
-
 	do {
 		res = nanosleep(&sleep_time, &sleep_time);
-		printf("sleep wake at %lu (res=%d, errno=%d (%s))\n", time(NULL), res, errno, strerror(errno));
 	} while (res != 0 && errno == EINTR);
-
-	printf("stop sleep at %lu\n", time(NULL));
 
 	return res;
 }

--- a/src/main/histogram.c
+++ b/src/main/histogram.c
@@ -56,8 +56,8 @@ typedef struct bucket_range_desc_s {
 // Forward declarations.
 //
 
-static int32_t _histogram_get_index(histogram_t* h, delay_t elapsed_us);
-static void _print_header(const histogram_t* h, uint64_t period_duration_us,
+LOCAL_HELPER int32_t _histogram_get_index(histogram_t* h, delay_t elapsed_us);
+LOCAL_HELPER void _print_header(const histogram_t* h, uint64_t period_duration_us,
 		uint64_t total_cnt, FILE* out_file);
 
 
@@ -306,7 +306,7 @@ histogram_print_info(const histogram_t* h, FILE* out_file)
 // Local helpers.
 //
 
-static int32_t
+LOCAL_HELPER int32_t
 _histogram_get_index(histogram_t* h, delay_t elapsed_us)
 {
 	int32_t bin_idx;
@@ -332,7 +332,7 @@ _histogram_get_index(histogram_t* h, delay_t elapsed_us)
 	return h->bounds[bin_idx].offset + bin_offset;
 }
 
-static void
+LOCAL_HELPER void
 _print_header(const histogram_t* h, uint64_t period_duration_us, uint64_t total_cnt,
 		FILE* out_file)
 {

--- a/src/main/latency_output.c
+++ b/src/main/latency_output.c
@@ -15,6 +15,7 @@
 
 #include <hdr_histogram/hdr_histogram_log.h>
 
+#include <common.h>
 #include <transaction.h>
 
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -111,13 +111,13 @@ static struct option long_options[] = {
 // Forward declarations.
 //
 
-static void print_usage(const char* program);
-static void print_args(args_t* args);
-static int validate_args(args_t* args);
-static stage_def_t* get_or_init_stage(args_t* args);
-static int set_args(int argc, char * const* argv, args_t* args);
-static void _load_defaults(args_t* args);
-static int _load_defaults_post(args_t* args);
+LOCAL_HELPER void print_usage(const char* program);
+LOCAL_HELPER void print_args(args_t* args);
+LOCAL_HELPER int validate_args(args_t* args);
+LOCAL_HELPER stage_def_t* get_or_init_stage(args_t* args);
+LOCAL_HELPER int set_args(int argc, char * const* argv, args_t* args);
+LOCAL_HELPER void _load_defaults(args_t* args);
+LOCAL_HELPER int _load_defaults_post(args_t* args);
 
 
 //==========================================================
@@ -165,7 +165,7 @@ main(int argc, char * const * argv)
 // Local helpers.
 //
 
-static void
+LOCAL_HELPER void
 print_usage(const char* program)
 {
 	printf("Usage: %s <options>\n", program);
@@ -495,7 +495,7 @@ print_usage(const char* program)
 	printf("\n");
 }
 
-static void
+LOCAL_HELPER void
 print_args(args_t* args)
 {
 	printf("hosts:                  %s\n", args->hosts);
@@ -649,7 +649,7 @@ print_args(args_t* args)
 	printf("auth mode:              %s\n", s);
 }
 
-static int
+LOCAL_HELPER int
 validate_args(args_t* args)
 {
 	if (args->start_key == ULLONG_MAX) {
@@ -767,7 +767,7 @@ validate_args(args_t* args)
 	return 0;
 }
 
-static stage_def_t*
+LOCAL_HELPER stage_def_t*
 get_or_init_stage(args_t* args)
 {
 	if (args->stage_defs.stages == NULL) {
@@ -783,7 +783,7 @@ get_or_init_stage(args_t* args)
 	return &args->stage_defs.stages[0];
 }
 
-static int
+LOCAL_HELPER int
 set_args(int argc, char * const* argv, args_t* args)
 {
 	int option_index = 0;
@@ -1184,7 +1184,7 @@ set_args(int argc, char * const* argv, args_t* args)
 	return validate_args(args);
 }
 
-static void
+LOCAL_HELPER void
 _load_defaults(args_t* args)
 {
 	args->hosts = strdup("127.0.0.1");
@@ -1241,7 +1241,7 @@ _load_defaults(args_t* args)
 	as_vector_append(&args->latency_percentiles, &p5);
 }
 
-static int
+LOCAL_HELPER int
 _load_defaults_post(args_t* args)
 {
 	int res = 0;

--- a/src/main/object_spec.c
+++ b/src/main/object_spec.c
@@ -80,37 +80,37 @@ struct consumer_state_s {
 // Forward declarations.
 //
 
-static uint32_t bin_spec_map_n_entries(const struct bin_spec_s* b);
-static void _print_parse_error(const char* err_msg, const char* obj_spec_str,
+LOCAL_HELPER uint32_t bin_spec_map_n_entries(const struct bin_spec_s* b);
+LOCAL_HELPER void _print_parse_error(const char* err_msg, const char* obj_spec_str,
 		const char* err_loc);
-static void bin_spec_free(struct bin_spec_s* bin_spec);
-static void _destroy_consumer_states(struct consumer_state_s* state);
-static int _parse_bin_types(as_vector* bin_specs, uint32_t* n_bins,
+LOCAL_HELPER void bin_spec_free(struct bin_spec_s* bin_spec);
+LOCAL_HELPER void _destroy_consumer_states(struct consumer_state_s* state);
+LOCAL_HELPER int _parse_bin_types(as_vector* bin_specs, uint32_t* n_bins,
 		const char* const obj_spec_str);
-static void bin_spec_free(struct bin_spec_s* bin_spec);
-static as_val* _gen_random_int(uint8_t range, as_random* random);
-static uint64_t raw_to_alphanum(uint64_t n);
-static as_val* _gen_random_str(uint32_t length, as_random* random);
-static as_val* _gen_random_bytes(uint32_t length, as_random* random,
+LOCAL_HELPER void bin_spec_free(struct bin_spec_s* bin_spec);
+LOCAL_HELPER as_val* _gen_random_int(uint8_t range, as_random* random);
+LOCAL_HELPER uint64_t raw_to_alphanum(uint64_t n);
+LOCAL_HELPER as_val* _gen_random_str(uint32_t length, as_random* random);
+LOCAL_HELPER as_val* _gen_random_bytes(uint32_t length, as_random* random,
 		float compression_ratio);
-static as_val* _gen_random_double(as_random* random);
-static as_val* _gen_random_list(const struct bin_spec_s* bin_spec,
+LOCAL_HELPER as_val* _gen_random_double(as_random* random);
+LOCAL_HELPER as_val* _gen_random_list(const struct bin_spec_s* bin_spec,
 		as_random* random, float compression_ratio);
-static as_val* _gen_random_map(const struct bin_spec_s* bin_spec,
+LOCAL_HELPER as_val* _gen_random_map(const struct bin_spec_s* bin_spec,
 		as_random* random, float compression_ratio);
-static as_val* bin_spec_random_val(const struct bin_spec_s* bin_spec,
+LOCAL_HELPER as_val* bin_spec_random_val(const struct bin_spec_s* bin_spec,
 		as_random* random, float compression_ratio);
-static size_t _sprint_bin(const struct bin_spec_s* bin, char** out_str,
+LOCAL_HELPER size_t _sprint_bin(const struct bin_spec_s* bin, char** out_str,
 		size_t str_size);
 
 #ifdef _TEST
-static void _dbg_validate_int(uint8_t range, as_integer* as_val);
-static void _dbg_validate_string(uint32_t length, as_string* as_val);
-static void _dbg_validate_bytes(uint32_t length, as_bytes* as_val);
-static void _dbg_validate_double(as_double* as_val);
-static void _dbg_validate_list(const struct bin_spec_s* bin_spec,
+LOCAL_HELPER void _dbg_validate_int(uint8_t range, as_integer* as_val);
+LOCAL_HELPER void _dbg_validate_string(uint32_t length, as_string* as_val);
+LOCAL_HELPER void _dbg_validate_bytes(uint32_t length, as_bytes* as_val);
+LOCAL_HELPER void _dbg_validate_double(as_double* as_val);
+LOCAL_HELPER void _dbg_validate_list(const struct bin_spec_s* bin_spec,
 		const as_list* as_val);
-static void _dbg_validate_map(const struct bin_spec_s* bin_spec,
+LOCAL_HELPER void _dbg_validate_map(const struct bin_spec_s* bin_spec,
 		const as_map* val);
 #endif /* _TEST */
 
@@ -123,7 +123,7 @@ static void _dbg_validate_map(const struct bin_spec_s* bin_spec,
  * converts a bytevector of 8 values between 0-35 to a bytevector of 8
  * alphanumeric characters
  */
-static inline uint64_t
+LOCAL_HELPER inline uint64_t
 raw_to_alphanum(uint64_t n)
 {
 	uint64_t x, y;
@@ -516,13 +516,13 @@ _dbg_validate_bin_spec(const struct bin_spec_s* bin_spec, const as_val* val)
 /*
  * gives the number of entries to put in the map
  */
-static uint32_t
+LOCAL_HELPER uint32_t
 bin_spec_map_n_entries(const struct bin_spec_s* b)
 {
 	return b->map.key->n_repeats;
 }
 
-static void
+LOCAL_HELPER void
 _print_parse_error(const char* err_msg, const char* obj_spec_str,
 		const char* err_loc)
 {
@@ -555,7 +555,7 @@ _print_parse_error(const char* err_msg, const char* obj_spec_str,
  * to be called when an error is encountered while parsing, and cleanup of the
  * consumer state managers and bin_specs is necessary
  */
-static void
+LOCAL_HELPER void
 _destroy_consumer_states(struct consumer_state_s* state)
 {
 	struct consumer_state_s* parent;
@@ -608,7 +608,7 @@ _destroy_consumer_states(struct consumer_state_s* state)
 }
 
 
-static int
+LOCAL_HELPER int
 _parse_bin_types(as_vector* bin_specs, uint32_t* n_bins,
 		const char* const obj_spec_str)
 {
@@ -998,7 +998,7 @@ _destroy_state:
 	return 0;
 }
 
-static void
+LOCAL_HELPER void
 bin_spec_free(struct bin_spec_s* bin_spec)
 {
 	switch (bin_spec->type) {
@@ -1024,7 +1024,7 @@ bin_spec_free(struct bin_spec_s* bin_spec)
 	}
 }
 
-static as_val*
+LOCAL_HELPER as_val*
 _gen_random_int(uint8_t range, as_random* random)
 {
 	as_integer* val;
@@ -1075,7 +1075,7 @@ _gen_random_int(uint8_t range, as_random* random)
  */
 #define MAX_SEED 4738381338321616896LU
 
-static as_val*
+LOCAL_HELPER as_val*
 _gen_random_str(uint32_t length, as_random* random)
 {
 	as_string* val;
@@ -1151,7 +1151,7 @@ _gen_random_str(uint32_t length, as_random* random)
 	return (as_val*) val;
 }
 
-static as_val*
+LOCAL_HELPER as_val*
 _gen_random_bytes(uint32_t length, as_random* random, float compression_ratio)
 {
 	as_bytes* val;
@@ -1165,7 +1165,7 @@ _gen_random_bytes(uint32_t length, as_random* random, float compression_ratio)
 	return (as_val*) val;
 }
 
-static as_val*
+LOCAL_HELPER as_val*
 _gen_random_double(as_random* random)
 {
 	as_double* val;
@@ -1175,7 +1175,7 @@ _gen_random_double(as_random* random)
 	return (as_val*) val;
 }
 
-static as_val*
+LOCAL_HELPER as_val*
 _gen_random_list(const struct bin_spec_s* bin_spec, as_random* random,
 		float compression_ratio)
 {
@@ -1209,7 +1209,7 @@ _gen_random_list(const struct bin_spec_s* bin_spec, as_random* random,
 	return (as_val*) list;
 }
 
-static as_val*
+LOCAL_HELPER as_val*
 _gen_random_map(const struct bin_spec_s* bin_spec, as_random* random,
 		float compression_ratio)
 {
@@ -1238,7 +1238,7 @@ _gen_random_map(const struct bin_spec_s* bin_spec, as_random* random,
 }
 
 
-static as_val*
+LOCAL_HELPER as_val*
 bin_spec_random_val(const struct bin_spec_s* bin_spec, as_random* random,
 		float compression_ratio)
 {
@@ -1271,7 +1271,7 @@ bin_spec_random_val(const struct bin_spec_s* bin_spec, as_random* random,
 	return val;
 }
 
-static size_t
+LOCAL_HELPER size_t
 _sprint_bin(const struct bin_spec_s* bin, char** out_str, size_t str_size)
 {
 	if (bin->n_repeats != 1) {
@@ -1316,7 +1316,7 @@ _sprint_bin(const struct bin_spec_s* bin, char** out_str, size_t str_size)
 
 #ifdef _TEST
 
-static void
+LOCAL_HELPER void
 _dbg_validate_int(uint8_t range, as_integer* as_val)
 {
 	ck_assert_msg(as_val != NULL, "Expected an integer, got something else");
@@ -1359,7 +1359,7 @@ _dbg_validate_int(uint8_t range, as_integer* as_val)
 	}
 }
 
-static void
+LOCAL_HELPER void
 _dbg_validate_string(uint32_t length, as_string* as_val)
 {
 	ck_assert_msg(as_val != NULL, "Expected a string, got something else");
@@ -1373,7 +1373,7 @@ _dbg_validate_string(uint32_t length, as_string* as_val)
 	}
 }
 
-static void
+LOCAL_HELPER void
 _dbg_validate_bytes(uint32_t length, as_bytes* as_val)
 {
 	ck_assert_msg(as_val != NULL, "Expected a bytes array, got something else");
@@ -1381,13 +1381,13 @@ _dbg_validate_bytes(uint32_t length, as_bytes* as_val)
 	ck_assert_int_eq(length, as_bytes_size(as_val));
 }
 
-static void
+LOCAL_HELPER void
 _dbg_validate_double(as_double* as_val)
 {
 	ck_assert_msg(as_val != NULL, "Expected a double, got something else");
 }
 
-static void
+LOCAL_HELPER void
 _dbg_validate_list(const struct bin_spec_s* bin_spec, const as_list* as_val)
 {
 	ck_assert_msg(as_val != NULL, "Expected a list, got something else");
@@ -1404,7 +1404,7 @@ _dbg_validate_list(const struct bin_spec_s* bin_spec, const as_list* as_val)
 }
 
 
-static void
+LOCAL_HELPER void
 _dbg_validate_map(const struct bin_spec_s* bin_spec, const as_map* val)
 {
 	as_hashmap_iterator iter;

--- a/src/main/queue.c
+++ b/src/main/queue.c
@@ -8,6 +8,7 @@
 #include <aerospike/as_atomic.h>
 #include <citrusleaf/alloc.h>
 
+#include <common.h>
 #include <queue.h>
 
 
@@ -15,7 +16,7 @@
 // Forward declarations.
 //
 
-static uint32_t next_pow2(uint32_t n);
+LOCAL_HELPER uint32_t next_pow2(uint32_t n);
 
 
 //==========================================================
@@ -77,7 +78,7 @@ queue_pop(queue_t* q)
 // Local helpers.
 //
 
-static uint32_t
+LOCAL_HELPER uint32_t
 next_pow2(uint32_t n)
 {
 	uint32_t leading_bits = __builtin_clz(n);

--- a/src/main/transaction.c
+++ b/src/main/transaction.c
@@ -53,68 +53,68 @@ struct async_data_s {
 //
 
 // Latency recrding helpers
-static void _record_read(cdata_t* cdata, uint64_t dt_us);
-static void _record_write(cdata_t* cdata, uint64_t dt_us);
+LOCAL_HELPER void _record_read(cdata_t* cdata, uint64_t dt_us);
+LOCAL_HELPER void _record_write(cdata_t* cdata, uint64_t dt_us);
 
 // Read/Write singular/batch synchronous operations
-static int _write_record_sync(tdata_t* tdata, cdata_t* cdata,
+LOCAL_HELPER int _write_record_sync(tdata_t* tdata, cdata_t* cdata,
 		thr_coord_t* coord, as_key* key, as_record* rec);
-static int _read_record_sync(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
+LOCAL_HELPER int _read_record_sync(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		stage_t* stage, as_key* key);
-static int _batch_read_record_sync(tdata_t* tdata, cdata_t* cdata,
+LOCAL_HELPER int _batch_read_record_sync(tdata_t* tdata, cdata_t* cdata,
 		thr_coord_t* coord, as_batch_read_records* records);
 
 // Read/Write singular/batch asynchronous operations
-static int _write_record_async(as_key* key, as_record* rec,
+LOCAL_HELPER int _write_record_async(as_key* key, as_record* rec,
 		struct async_data_s* adata, cdata_t* cdata);
-static int _read_record_async(as_key* key, struct async_data_s* adata,
+LOCAL_HELPER int _read_record_async(as_key* key, struct async_data_s* adata,
 		cdata_t* cdata, stage_t* stage);
-static int _batch_read_record_async(as_batch_read_records* keys,
+LOCAL_HELPER int _batch_read_record_async(as_batch_read_records* keys,
 		struct async_data_s* adata, cdata_t* cdata);
 
 // Thread worker helper methods
-static void _calculate_subrange(uint64_t key_start, uint64_t key_end,
+LOCAL_HELPER void _calculate_subrange(uint64_t key_start, uint64_t key_end,
 		uint32_t t_idx, uint32_t n_threads, uint64_t* t_start, uint64_t* t_end);
-static void _gen_key(uint64_t key_val, as_key* key, const cdata_t* cdata);
-static void _gen_record(as_record* rec, as_random* random, const cdata_t* cdata,
+LOCAL_HELPER void _gen_key(uint64_t key_val, as_key* key, const cdata_t* cdata);
+LOCAL_HELPER void _gen_record(as_record* rec, as_random* random, const cdata_t* cdata,
 		tdata_t* tdata, stage_t* stage);
-static void _gen_nil_record(as_record* rec, const cdata_t* cdata,
+LOCAL_HELPER void _gen_nil_record(as_record* rec, const cdata_t* cdata,
 		stage_t* stage);
-static void throttle(tdata_t* tdata, thr_coord_t* coord);
+LOCAL_HELPER void throttle(tdata_t* tdata, thr_coord_t* coord);
 
 // Synchronous workload methods
-static void linear_writes(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
+LOCAL_HELPER void linear_writes(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		stage_t* stage);
-static void random_read_write(tdata_t* tdata, cdata_t* cdata,
+LOCAL_HELPER void random_read_write(tdata_t* tdata, cdata_t* cdata,
 		thr_coord_t* coord, stage_t* stage);
-static void linear_deletes(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
+LOCAL_HELPER void linear_deletes(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		stage_t* stage);
 
 // Asynchronous workload methods
-static void _async_listener(as_error* err, void* udata,
+LOCAL_HELPER void _async_listener(as_error* err, void* udata,
 		as_event_loop* event_loop);
-static void _async_read_listener(as_error* err, as_record* rec, void* udata,
+LOCAL_HELPER void _async_read_listener(as_error* err, as_record* rec, void* udata,
 		as_event_loop* event_loop);
-static void _async_write_listener(as_error* err, void* udata,
+LOCAL_HELPER void _async_write_listener(as_error* err, void* udata,
 		as_event_loop* event_loop);
-static void _async_batch_read_listener(as_error* err,
+LOCAL_HELPER void _async_batch_read_listener(as_error* err,
 		as_batch_read_records* records, void* udata, as_event_loop* event_loop);
-static struct async_data_s* queue_pop_wait(queue_t* adata_q);
-static void linear_writes_async(tdata_t* tdata, cdata_t* cdata,
+LOCAL_HELPER struct async_data_s* queue_pop_wait(queue_t* adata_q);
+LOCAL_HELPER void linear_writes_async(tdata_t* tdata, cdata_t* cdata,
 	   thr_coord_t* coord, stage_t* stage, queue_t* adata_q);
-static void rand_read_write_async(tdata_t* tdata, cdata_t* cdata,
+LOCAL_HELPER void rand_read_write_async(tdata_t* tdata, cdata_t* cdata,
 	   thr_coord_t* coord, stage_t* stage, queue_t* adata_q);
-static void linear_deletes_async(tdata_t* tdata, cdata_t* cdata,
+LOCAL_HELPER void linear_deletes_async(tdata_t* tdata, cdata_t* cdata,
 	   thr_coord_t* coord, stage_t* stage, queue_t* adata_q);
 
 // Main worker thread loop
-static void do_sync_workload(tdata_t* tdata, cdata_t* cdata,
+LOCAL_HELPER void do_sync_workload(tdata_t* tdata, cdata_t* cdata,
 		thr_coord_t* coord, stage_t* stage);
-static void do_async_workload(tdata_t* tdata, cdata_t* cdata,
+LOCAL_HELPER void do_async_workload(tdata_t* tdata, cdata_t* cdata,
 		thr_coord_t* coord, stage_t* stage);
-static void init_stage(const cdata_t* cdata, tdata_t* tdata,
+LOCAL_HELPER void init_stage(const cdata_t* cdata, tdata_t* tdata,
 		stage_t* stage);
-static void terminate_stage(const cdata_t* cdata, tdata_t* tdata,
+LOCAL_HELPER void terminate_stage(const cdata_t* cdata, tdata_t* tdata,
 		stage_t* stage);
 
 
@@ -161,7 +161,7 @@ transaction_worker(void* udata)
  * Latency recording helpers
  *****************************************************************************/
 
-static void
+LOCAL_HELPER void
 _record_read(cdata_t* cdata, uint64_t dt_us)
 {
 	if (cdata->latency) {
@@ -176,7 +176,7 @@ _record_read(cdata_t* cdata, uint64_t dt_us)
 	as_incr_uint32(&cdata->read_count);
 }
 
-static void
+LOCAL_HELPER void
 _record_write(cdata_t* cdata, uint64_t dt_us)
 {
 	if (cdata->latency) {
@@ -196,7 +196,7 @@ _record_write(cdata_t* cdata, uint64_t dt_us)
  * Read/Write singular/batch synchronous operations
  *****************************************************************************/
 
-static int
+LOCAL_HELPER int
 _write_record_sync(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		as_key* key, as_record* rec)
 {
@@ -231,7 +231,7 @@ _write_record_sync(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 	return -1;
 }
 
-static int
+LOCAL_HELPER int
 _read_record_sync(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		stage_t* stage, as_key* key)
 {
@@ -279,7 +279,7 @@ _read_record_sync(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 	return status;
 }
 
-static int
+LOCAL_HELPER int
 _batch_read_record_sync(tdata_t* tdata, cdata_t* cdata,
 		thr_coord_t* coord, as_batch_read_records* records)
 {
@@ -320,7 +320,7 @@ _batch_read_record_sync(tdata_t* tdata, cdata_t* cdata,
  * Read/Write singular/batch asynchronous operations
  *****************************************************************************/
 
-static int
+LOCAL_HELPER int
 _write_record_async(as_key* key, as_record* rec, struct async_data_s* adata,
 		cdata_t* cdata)
 {
@@ -339,7 +339,7 @@ _write_record_async(as_key* key, as_record* rec, struct async_data_s* adata,
 	return status;
 }
 
-static int
+LOCAL_HELPER int
 _read_record_async(as_key* key, struct async_data_s* adata, cdata_t* cdata,
 		stage_t* stage)
 {
@@ -366,7 +366,7 @@ _read_record_async(as_key* key, struct async_data_s* adata, cdata_t* cdata,
 	return status;
 }
 
-static int
+LOCAL_HELPER int
 _batch_read_record_async(as_batch_read_records* keys, struct async_data_s* adata,
 		cdata_t* cdata)
 {
@@ -394,7 +394,7 @@ _batch_read_record_async(as_batch_read_records* keys, struct async_data_s* adata
  * calculates the subrange of keys that the given thread should operate on,
  * which is done by evenly dividing the interval into n_threads intervals
  */
-static void
+LOCAL_HELPER void
 _calculate_subrange(uint64_t key_start, uint64_t key_end, uint32_t t_idx,
 		uint32_t n_threads, uint64_t* t_start, uint64_t* t_end)
 {
@@ -403,7 +403,7 @@ _calculate_subrange(uint64_t key_start, uint64_t key_end, uint32_t t_idx,
 	*t_end   = key_start + ((n_keys * (t_idx + 1)) / n_threads);
 }
 
-static void
+LOCAL_HELPER void
 _gen_key(uint64_t key_val, as_key* key, const cdata_t* cdata)
 {
 	as_key_init_int64(key, cdata->namespace, cdata->set, key_val);
@@ -412,7 +412,7 @@ _gen_key(uint64_t key_val, as_key* key, const cdata_t* cdata)
 /*
  * generates a record with given key following the obj_spec in cdata
  */
-static void
+LOCAL_HELPER void
 _gen_record(as_record* rec, as_random* random, const cdata_t* cdata,
 		tdata_t* tdata, stage_t* stage)
 {
@@ -444,7 +444,7 @@ _gen_record(as_record* rec, as_random* random, const cdata_t* cdata,
 /*
  * generates a record with all nil bins (used to remove records)
  */
-static void
+LOCAL_HELPER void
 _gen_nil_record(as_record* rec, const cdata_t* cdata, stage_t* stage)
 {
 	uint32_t n_objs = obj_spec_n_bins(&stage->obj_spec);
@@ -461,7 +461,7 @@ _gen_nil_record(as_record* rec, const cdata_t* cdata, stage_t* stage)
 /*
  * throttler to be called between every transaction
  */
-static void
+LOCAL_HELPER void
 throttle(tdata_t* tdata, thr_coord_t* coord)
 {
 	struct timespec wake_up;
@@ -482,7 +482,7 @@ throttle(tdata_t* tdata, thr_coord_t* coord)
  * TODO add work queue that threads can pull batches of keys from, rather than
  * having each thread take a predefined segment of the set of all keys
  */
-static void
+LOCAL_HELPER void
 linear_writes(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		stage_t* stage)
 {
@@ -520,7 +520,7 @@ linear_writes(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 	thr_coordinator_complete(coord);
 }
 
-static void
+LOCAL_HELPER void
 random_read_write(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		stage_t* stage)
 {
@@ -594,7 +594,7 @@ random_read_write(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 	}
 }
 
-static void
+LOCAL_HELPER void
 linear_deletes(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		stage_t* stage)
 {
@@ -637,7 +637,7 @@ linear_deletes(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
  * Asynchronous workload methods
  *****************************************************************************/
 
-static void
+LOCAL_HELPER void
 _async_listener(as_error* err, void* udata, as_event_loop* event_loop)
 {
 	struct async_data_s* adata = (struct async_data_s*) udata;
@@ -698,20 +698,20 @@ _async_listener(as_error* err, void* udata, as_event_loop* event_loop)
 	queue_push(adata->adata_q, adata);
 }
 
-static void
+LOCAL_HELPER void
 _async_read_listener(as_error* err, as_record* rec, void* udata,
 		as_event_loop* event_loop)
 {
 	_async_listener(err, udata, event_loop);
 }
 
-static void
+LOCAL_HELPER void
 _async_write_listener(as_error* err, void* udata, as_event_loop* event_loop)
 {
 	_async_listener(err, udata, event_loop);
 }
 
-static void
+LOCAL_HELPER void
 _async_batch_read_listener(as_error* err, as_batch_read_records* records,
 		void* udata, as_event_loop* event_loop)
 {
@@ -721,7 +721,7 @@ _async_batch_read_listener(as_error* err, as_batch_read_records* records,
 	}
 }
 
-static struct async_data_s*
+LOCAL_HELPER struct async_data_s*
 queue_pop_wait(queue_t* adata_q)
 {
 	struct async_data_s* adata;
@@ -737,7 +737,7 @@ queue_pop_wait(queue_t* adata_q)
 	return adata;
 }
 
-static void
+LOCAL_HELPER void
 linear_writes_async(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		stage_t* stage, queue_t* adata_q)
 {
@@ -780,7 +780,7 @@ linear_writes_async(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 	thr_coordinator_complete(coord);
 }
 
-static void
+LOCAL_HELPER void
 rand_read_write_async(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		stage_t* stage, queue_t* adata_q)
 {
@@ -864,7 +864,7 @@ rand_read_write_async(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 	}
 }
 
-static void
+LOCAL_HELPER void
 linear_deletes_async(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		stage_t* stage, queue_t* adata_q)
 {
@@ -912,7 +912,7 @@ linear_deletes_async(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
  * Main worker thread loop
  *****************************************************************************/
 
-static void
+LOCAL_HELPER void
 do_sync_workload(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		stage_t* stage)
 {
@@ -929,7 +929,7 @@ do_sync_workload(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 	}
 }
 
-static void
+LOCAL_HELPER void
 do_async_workload(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 		stage_t* stage)
 {
@@ -984,7 +984,7 @@ do_async_workload(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 	cf_free(adatas);
 }
 
-static void
+LOCAL_HELPER void
 init_stage(const cdata_t* cdata, tdata_t* tdata, stage_t* stage)
 {
 	if (stage->tps == 0) {
@@ -1008,7 +1008,7 @@ init_stage(const cdata_t* cdata, tdata_t* tdata, stage_t* stage)
 	}
 }
 
-static void
+LOCAL_HELPER void
 terminate_stage(const cdata_t* cdata, tdata_t* tdata, stage_t* stage)
 {
 	dyn_throttle_free(&tdata->dyn_throttle);

--- a/src/main/transaction.c
+++ b/src/main/transaction.c
@@ -540,8 +540,6 @@ random_read_write(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 
 	batch_size = stage->batch_size;
 
-	printf("thread %d start workload at %lu\n", tdata->t_idx, time(NULL));
-
 	while (as_load_uint8((uint8_t*) &tdata->do_work)) {
 		// roll the die
 		uint32_t die = as_random_next_uint32(tdata->random);
@@ -594,7 +592,6 @@ random_read_write(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 			as_key_destroy(&key);
 		}
 	}
-	printf("thread %d stop workload at %lu\n", tdata->t_idx, time(NULL));
 }
 
 static void

--- a/src/main/transaction.c
+++ b/src/main/transaction.c
@@ -540,6 +540,8 @@ random_read_write(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 
 	batch_size = stage->batch_size;
 
+	printf("thread %d start workload at %lu\n", tdata->t_idx, time(NULL));
+
 	while (as_load_uint8((uint8_t*) &tdata->do_work)) {
 		// roll the die
 		uint32_t die = as_random_next_uint32(tdata->random);
@@ -592,6 +594,7 @@ random_read_write(tdata_t* tdata, cdata_t* cdata, thr_coord_t* coord,
 			as_key_destroy(&key);
 		}
 	}
+	printf("thread %d stop workload at %lu\n", tdata->t_idx, time(NULL));
 }
 
 static void

--- a/src/main/workload.c
+++ b/src/main/workload.c
@@ -105,17 +105,17 @@ static const cyaml_config_t config = {
  * the list of bin names will be returned, and n_bins will be populated with
  * the number of bins in the returned array
  */
-static void* _parse_bins_selection(const char* bins_str,
+LOCAL_HELPER void* _parse_bins_selection(const char* bins_str,
 		const obj_spec_t* obj_spec, const char* stage_bin_name,
 		uint32_t* n_bins_ptr, uint8_t mode);
 /*
  * cleanup helper used by _parse_bins_selection on failure
  */
-static void _parse_bins_destroy(as_vector* read_bins, uint8_t mode);
+LOCAL_HELPER void _parse_bins_destroy(as_vector* read_bins, uint8_t mode);
 /*
  * frees the bins selection array created from parse_bins_selection in STR mode
  */
-static void _free_bins_selection(char** bins);
+LOCAL_HELPER void _free_bins_selection(char** bins);
 
 
 //==========================================================
@@ -511,7 +511,7 @@ void stages_print_defs(const stage_defs_t* stage_defs,
 // Local helpers.
 //
 
-static void*
+LOCAL_HELPER void*
 _parse_bins_selection(const char* bins_str, const obj_spec_t* obj_spec,
 		const char* stage_bin_name, uint32_t* n_bins_ptr, uint8_t mode)
 {
@@ -594,7 +594,7 @@ _parse_bins_selection(const char* bins_str, const obj_spec_t* obj_spec,
 	return bin_list;
 }
 
-static void
+LOCAL_HELPER void
 _parse_bins_destroy(as_vector* read_bins, uint8_t mode)
 {
 
@@ -609,7 +609,7 @@ _parse_bins_destroy(as_vector* read_bins, uint8_t mode)
 	as_vector_destroy(read_bins);
 }
 
-static void
+LOCAL_HELPER void
 _free_bins_selection(char** bins)
 {
 	if (bins != NULL) {

--- a/src/test/benchmark_tests.h
+++ b/src/test/benchmark_tests.h
@@ -4,6 +4,7 @@
 
 Suite* setup_suite(void);
 Suite* common_suite(void);
+Suite* coordinator_suite(void);
 Suite* dyn_throttle_suite(void);
 Suite* sanity_suite(void);
 Suite* hdr_histogram_suite(void);

--- a/src/test/coordinator_test.c
+++ b/src/test/coordinator_test.c
@@ -1,0 +1,134 @@
+
+#include <signal.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include <check.h>
+
+#include <coordinator.h>
+
+#include "main.h"
+
+
+#define TEST_SUITE_NAME "thread coordinator"
+
+
+/*
+ * forward declare all local functions from coordinator (which aren't visible
+ * from the header file)
+ */
+extern int _has_not_happened(const struct timespec* time);
+extern int _sleep_for(uint64_t n_secs);
+extern void _halt_threads(thr_coord_t* coord,
+		tdata_t** tdatas, uint32_t n_threads);
+extern void _terminate_threads(thr_coord_t* coord,
+		tdata_t** tdatas, uint32_t n_threads);
+extern void _release_threads(thr_coord_t* coord,
+		tdata_t** tdatas, uint32_t n_threads);
+extern void _finish_req_duration(thr_coord_t* coord);
+extern void clear_cdata_counts(cdata_t* cdata);
+
+
+/*
+ * fixtures to use to silence stderr
+ */
+static void 
+silence_stderr_setup(void) 
+{
+	// redirect stdout and stderr to /dev/null
+	freopen("/dev/null", "w", stdout);
+	freopen("/dev/null", "w", stderr);
+}
+
+static void
+silence_stderr_teardown(void)
+{
+}
+
+
+#define SLEEP_FOR_TEST(n_secs) \
+	do { \
+		struct timespec before, after; \
+		clock_gettime(CLOCK_MONOTONIC, &before); \
+		ck_assert_int_eq(_sleep_for((n_secs)), 0); \
+		clock_gettime(CLOCK_MONOTONIC, &after); \
+		ck_assert_int_gt((after.tv_sec - before.tv_sec) * 1000000000LU + (after.tv_nsec - before.tv_nsec), (n_secs) * 1000000000LU); \
+	} while (0)
+
+
+static void
+sigusr1_handle(int signum)
+{
+	// do nothing
+	(void) signum;
+}
+
+
+START_TEST(test_sleep_for_simple)
+{
+	SLEEP_FOR_TEST(1);
+}
+END_TEST
+
+
+START_TEST(test_sleep_for_longer)
+{
+	SLEEP_FOR_TEST(10);
+}
+END_TEST
+
+
+/*
+ * with signal interrupts, the sleep should still last the specified duration
+ */
+START_TEST(test_sleep_for_signal_interrupts)
+{
+	pid_t pid;
+	if ((pid = fork()) == 0) {
+		// set the fork status of libtest to true so the assertions will call
+		// exit(1) instead of jumping to the exit handler on failure
+		set_fork_status(CK_FORK);
+
+		sighandler_t prev_sig_handle = signal(SIGUSR1, sigusr1_handle);
+		ck_assert_ptr_ne(prev_sig_handle, SIG_ERR);
+
+		SLEEP_FOR_TEST(2);
+
+		// return with exit code 0
+		exit(0);
+	}
+	else {
+		// raise some signals
+		for (int i = 0; i < 1000; i++) {
+			usleep(500);
+			kill(pid, SIGUSR1);
+		}
+
+		int status;
+		ck_assert_int_eq(waitpid(pid, &status, 0), pid);
+		ck_assert_msg(WIFEXITED(status) && (WEXITSTATUS(status) == 0),
+				"The sleep did not last the specified duration");
+	}
+}
+END_TEST
+
+
+Suite* coordinator_suite(void)
+{
+	Suite* s;
+	TCase* tc_core;
+
+	s = suite_create("Thread Coordinator");
+
+	tc_core = tcase_create("Core");
+	tcase_set_timeout(tc_core, 100);
+	tcase_add_checked_fixture(tc_core, silence_stderr_setup,
+			silence_stderr_teardown);
+	tcase_add_test(tc_core, test_sleep_for_simple);
+	tcase_add_test(tc_core, test_sleep_for_longer);
+	tcase_add_test(tc_core, test_sleep_for_signal_interrupts);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -19,27 +19,37 @@
 #include <check.h>
 #include "benchmark.h"
 #include "benchmark_tests.h"
+
+
+static SRunner* g_sr;
+
+void
+set_fork_status(enum fork_status status)
+{
+	srunner_set_fork_status(g_sr, status);
+}
+
 int 
 main(void) {
 	int number_failed;
 	Suite* s;
-	SRunner* sr;
 
 	s = sanity_suite();
-	sr = srunner_create(s);
-    srunner_add_suite(sr, setup_suite());
-    srunner_add_suite(sr, common_suite());
-    srunner_add_suite(sr, dyn_throttle_suite());
-    srunner_add_suite(sr, hdr_histogram_suite());
-    srunner_add_suite(sr, hdr_histogram_log_suite());
-    srunner_add_suite(sr, histogram_suite());
-    srunner_add_suite(sr, obj_spec_suite());
-    srunner_add_suite(sr, yaml_parse_suite());
+	g_sr = srunner_create(s);
+    srunner_add_suite(g_sr, setup_suite());
+    srunner_add_suite(g_sr, common_suite());
+    srunner_add_suite(g_sr, coordinator_suite());
+    srunner_add_suite(g_sr, dyn_throttle_suite());
+    srunner_add_suite(g_sr, hdr_histogram_suite());
+    srunner_add_suite(g_sr, hdr_histogram_log_suite());
+    srunner_add_suite(g_sr, histogram_suite());
+    srunner_add_suite(g_sr, obj_spec_suite());
+    srunner_add_suite(g_sr, yaml_parse_suite());
 
 	//srunner_set_fork_status(sr, CK_NOFORK);
 
-	srunner_run_all(sr, CK_NORMAL);
-	number_failed = srunner_ntests_failed(sr);
-	srunner_free(sr);
+	srunner_run_all(g_sr, CK_NORMAL);
+	number_failed = srunner_ntests_failed(g_sr);
+	srunner_free(g_sr);
 	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
Tibor found that when running a single workloads stage for a long period of time (3 hours), the stage unexpectedly terminated 35 minutes in. I suspect this is because "usleep" both isn't meant to be used for long sleep durations, and the sleep functions can return before the expected duration has complete in some cases. I've replaced usleep with "_safe_sleep", which uses nanosleep and loops until the entire duration is complete.