### PR TITLE
print error message when running with an unknown parameter

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1178,6 +1178,7 @@ set_args(int argc, char * const* argv, args_t* args)
 				break;
 
 			default:
+				fprintf(stderr, "Unknown parameter '%c'\n", c);
 				return 1;
 		}
 	}

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1179,6 +1179,7 @@ set_args(int argc, char * const* argv, args_t* args)
 
 			default:
 				fprintf(stderr, "Unknown parameter '%c'\n", c);
+			case '?':
 				return 1;
 		}
 	}


### PR DESCRIPTION
Not sure how I missed this, but this is probably important to have in the tool.