### PR TITLE
Remove latency shift/power, random read-only integration testing

### DIFF
--- a/src/include/benchmark.h
+++ b/src/include/benchmark.h
@@ -68,8 +68,6 @@ typedef struct args_s {
 	int max_retries;
 	bool debug;
 	bool latency;
-	int latency_columns;
-	int latency_shift;
 	as_vector latency_percentiles;
 	bool latency_histogram;
 	char* histogram_output;

--- a/src/main/benchmark_init.c
+++ b/src/main/benchmark_init.c
@@ -593,7 +593,7 @@ print_usage(const char* program)
 	printf("   Use TLS for node login only.\n");
 	printf("\n");
 
-	printf("   --auth {INTERNAL,EXTERNAL,EXTERNAL_SECURE} # Default: INTERNAL\n");
+	printf("   --auth {INTERNAL,EXTERNAL,EXTERNAL_SECURE,PKI} # Default: INTERNAL\n");
 	printf("   Set authentication mode when user/password is defined.\n");
 	printf("\n");
 }
@@ -743,6 +743,9 @@ print_args(args_t* args)
 			break;
 		case AS_AUTH_EXTERNAL_INSECURE:
 			s = "EXTERNAL_INSECURE";
+			break;
+		case AS_AUTH_PKI:
+			s = "PKI";
 			break;
 		default:
 			s = "unknown";

--- a/src/main/benchmark_init.c
+++ b/src/main/benchmark_init.c
@@ -628,9 +628,6 @@ print_args(args_t* args)
 	printf("debug:                  %s\n", boolstring(args->debug));
 
 	if (args->latency) {
-		printf("latency:                %d columns, shift exponent %d\n",
-				args->latency_columns, args->latency_shift);
-
 		printf("hdr histogram format:   UTC-time, seconds-running, total, "
 				"min-latency, max-latency, ");
 		for (uint32_t i = 0; i < args->latency_percentiles.size; i++) {
@@ -800,18 +797,6 @@ validate_args(args_t* args)
 	if (args->write_total_timeout < 0) {
 		printf("Invalid write total timeout: %d  Valid values: [>= 0]\n",
 				args->write_total_timeout);
-		return 1;
-	}
-
-	if (args->latency_columns < 0 || args->latency_columns > 16) {
-		printf("Invalid latency columns: %d  Valid values: [1-16]\n",
-				args->latency_columns);
-		return 1;
-	}
-
-	if (args->latency_shift < 0 || args->latency_shift > 5) {
-		printf("Invalid latency shift: %d  Valid values: [1-5]\n",
-				args->latency_shift);
 		return 1;
 	}
 
@@ -1428,8 +1413,6 @@ _load_defaults(args_t* args)
 	args->max_retries = 1;
 	args->debug = false;
 	args->latency = false;
-	args->latency_columns = 4;
-	args->latency_shift = 3;
 	as_vector_init(&args->latency_percentiles, sizeof(double), 5);
 	args->latency_histogram = false;
 	args->histogram_output = NULL;

--- a/src/test/integration/test_random.py
+++ b/src/test/integration/test_random.py
@@ -61,3 +61,39 @@ def test_random_read_batch_async():
 			cnt += 1
 	assert(cnt == n_recs)
 
+def test_random_read_only():
+	lib.run_benchmark("--workload I --start-key 0 --keys 100")
+
+	recs = [lib.get_record(key) for key in range(0, 100)]
+
+	lib.run_benchmark("--duration 1 --workload RU,100 --start-key 0 --keys 100", do_reset=False)
+
+	# this should exactly match recs
+	recs2 = [lib.get_record(key) for key in range(0, 100)]
+
+	for rec1, rec2 in zip(recs, recs2):
+		(dig1, meta1, bins1) = rec1
+		(dig2, meta2, bins2) = rec2
+
+		assert(len(rec1) == len(rec2))
+		for bin_name in bins1:
+			assert(bins1[bin_name] == bins2[bin_name])
+
+def test_random_read_only_async():
+	lib.run_benchmark("--workload I --start-key 0 --keys 100 --async")
+
+	recs = [lib.get_record(key) for key in range(0, 100)]
+
+	lib.run_benchmark("--duration 1 --workload RU,100 --start-key 0 --keys 100 --async", do_reset=False)
+
+	# this should exactly match recs
+	recs2 = [lib.get_record(key) for key in range(0, 100)]
+
+	for rec1, rec2 in zip(recs, recs2):
+		(dig1, meta1, bins1) = rec1
+		(dig2, meta2, bins2) = rec2
+
+		assert(len(rec1) == len(rec2))
+		for bin_name in bins1:
+			assert(bins1[bin_name] == bins2[bin_name])
+


### PR DESCRIPTION
Remove dead code since --latency was repurposed for HDR histograms instead of the old powers-of-two latency histogram.