### PR TITLE
add some missing END_TEST macros

### DIFF
--- a/src/test/unit/common_test.c
+++ b/src/test/unit/common_test.c
@@ -16,6 +16,7 @@ START_TEST(ddl_0)
 {
 	ck_assert_int_eq(dec_display_len(0), 1);
 }
+END_TEST
 
 START_TEST(ddl_1_digit)
 {

--- a/src/test/unit/hdr_histogram_log_test.c
+++ b/src/test/unit/hdr_histogram_log_test.c
@@ -955,6 +955,7 @@ START_TEST(test_zz_encode_1_byte)
 		ck_assert_int_eq(val, dval);
 	}
 }
+END_TEST
 
 
 START_TEST(test_zz_encode_2_bytes)
@@ -974,6 +975,7 @@ START_TEST(test_zz_encode_2_bytes)
 		ck_assert_int_eq(val, dval);
 	}
 }
+END_TEST
 
 
 START_TEST(test_zz_encode_3_bytes)
@@ -993,6 +995,7 @@ START_TEST(test_zz_encode_3_bytes)
 		ck_assert_int_eq(val, dval);
 	}
 }
+END_TEST
 
 
 START_TEST(test_zz_encode_4_bytes)
@@ -1012,6 +1015,7 @@ START_TEST(test_zz_encode_4_bytes)
 		ck_assert_int_eq(val, dval);
 	}
 }
+END_TEST
 
 
 START_TEST(test_zz_encode_5_bytes)
@@ -1031,6 +1035,7 @@ START_TEST(test_zz_encode_5_bytes)
 		ck_assert_int_eq(val, dval);
 	}
 }
+END_TEST
 
 
 START_TEST(test_zz_encode_6_bytes)
@@ -1050,6 +1055,7 @@ START_TEST(test_zz_encode_6_bytes)
 		ck_assert_int_eq(val, dval);
 	}
 }
+END_TEST
 
 
 START_TEST(test_zz_encode_7_bytes)
@@ -1069,6 +1075,7 @@ START_TEST(test_zz_encode_7_bytes)
 		ck_assert_int_eq(val, dval);
 	}
 }
+END_TEST
 
 
 START_TEST(test_zz_encode_8_bytes)
@@ -1088,6 +1095,7 @@ START_TEST(test_zz_encode_8_bytes)
 		ck_assert_int_eq(val, dval);
 	}
 }
+END_TEST
 
 
 START_TEST(test_zz_encode_9_bytes)
@@ -1113,6 +1121,7 @@ START_TEST(test_zz_encode_9_bytes)
 		val = next_val;
 	}
 }
+END_TEST
 
 
 Suite*

--- a/src/test/unit/histogram_test.c
+++ b/src/test/unit/histogram_test.c
@@ -733,6 +733,7 @@ START_TEST(default_underflow_cnt)
 	histogram_t* h = &hist;
 	ck_assert_int_eq(h->underflow_cnt, 99);
 }
+END_TEST
 
 /*
  * verifies the overflow count in the default histgoram setup
@@ -742,6 +743,7 @@ START_TEST(default_overflow_cnt)
 	histogram_t* h = &hist;
 	ck_assert_int_eq(h->overflow_cnt, 500);
 }
+END_TEST
 
 /*
  * verifies bin counts in the first range of bins
@@ -753,6 +755,7 @@ START_TEST(default_range_1_cnt)
 		ck_assert_int_eq(histogram_get_count(h, i), 100);
 	}
 }
+END_TEST
 
 /*
  * verifies bin counts in the second range of bins
@@ -764,6 +767,7 @@ START_TEST(default_range_2_cnt)
 		ck_assert_int_eq(histogram_get_count(h, i), 1000);
 	}
 }
+END_TEST
 
 /*
  * verifies bin counts in the third range of bins
@@ -775,6 +779,7 @@ START_TEST(default_range_3_cnt)
 		ck_assert_int_eq(histogram_get_count(h, i), 4000);
 	}
 }
+END_TEST
 
 /*
  * verifies clearing the histogram
@@ -789,6 +794,7 @@ START_TEST(default_clear)
 	ck_assert_int_eq(h->underflow_cnt, 0);
 	ck_assert_int_eq(h->overflow_cnt, 0);
 }
+END_TEST
 
 /*
  * verifies that print_clear actually clears
@@ -806,6 +812,7 @@ START_TEST(default_print_clear_clears)
 	ck_assert_int_eq(h->underflow_cnt, 0);
 	ck_assert_int_eq(h->overflow_cnt, 0);
 }
+END_TEST
 
 /*
  * verifies calc_total
@@ -816,6 +823,7 @@ START_TEST(default_calc_total)
 
 	ck_assert_int_eq(histogram_calc_total(h), 128499);
 }
+END_TEST
 
 
 /**

--- a/src/test/unit/obj_spec_parse_test.c
+++ b/src/test/unit/obj_spec_parse_test.c
@@ -242,7 +242,8 @@ END_TEST \
 START_TEST(test_name ## _valid) \
 { \
 	_test_valid(obj_spec_str, expected_out_str, write_bins, n_write_bins); \
-}
+}\
+END_TEST
 
 #define DEFINE_TCASE_DIFF(test_name, obj_spec_str, expected_out_str) \
 	DEFINE_TCASE_DIFF_WRITE_BINS(test_name, obj_spec_str, expected_out_str, \


### PR DESCRIPTION
I ran into some build errors when trying to run `make test` on aerospike-benchmark, and found that there were some missing END_TEST macros in a few of the unit test files. This commit adds those END_TEST macros after some test definitions.