### PR TITLE
Fix version and help return code and version number.

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -11,8 +11,7 @@
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "c11",
             "cppStandard": "c++17",
-            "intelliSenseMode": "gcc-x86",
-            "configurationProvider": "ms-vscode.makefile-tools"
+            "intelliSenseMode": "gcc-x86"
         }
     ],
     "version": 4

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -11,7 +11,8 @@
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "c11",
             "cppStandard": "c++17",
-            "intelliSenseMode": "gcc-x86"
+            "intelliSenseMode": "gcc-x86",
+            "configurationProvider": "ms-vscode.makefile-tools"
         }
     ],
     "version": 4

--- a/Makefile
+++ b/Makefile
@@ -10,31 +10,33 @@ endif
 
 ARCH = $(shell uname -m)
 PLATFORM = $(OS)-$(ARCH)
+VERSION := $(shell git describe 2>/dev/null; if [ $${?} != 0 ]; then echo 'unknown'; fi)
 ROOT = $(CURDIR)
 NAME = $(shell basename $(ROOT))
 OS = $(shell uname)
 ifeq ($(OS),Darwin)
-	ARCH = $(shell uname -m)
+  ARCH = $(shell uname -m)
 else
-	ARCH = $(shell uname -m)
+  ARCH = $(shell uname -m)
 endif
 
 CMAKE3_CHECK := $(shell cmake3 --help > /dev/null 2>&1 || (echo "cmake3 not found"))
 CMAKE_CHECK := $(shell cmake --help > /dev/null 2>&1 || (echo "cmake not found"))
 
 ifeq ($(CMAKE3_CHECK),)
-	CMAKE := cmake3
+  CMAKE := cmake3
 else
 ifeq ($(CMAKE_CHECK),)
-	CMAKE := cmake
+  CMAKE := cmake
 else
-	$(error "no cmake binary found")
+  $(error "no cmake binary found")
 endif
 endif
 
 CFLAGS = -std=gnu99 -Wall -fPIC -O3 -MMD -MP
 CFLAGS += -fno-common -fno-strict-aliasing
 CFLAGS += -D_FILE_OFFSET_BITS=64 -D_REENTRANT -D_GNU_SOURCE
+CFLAGS += -DTOOL_VERSION=\"$(VERSION)\"
 
 DIR_LIBYAML ?= $(ROOT)/modules/libyaml
 DIR_LIBYAML_BUILD := $(DIR_LIBYAML)/build

--- a/src/main/benchmark_init.c
+++ b/src/main/benchmark_init.c
@@ -47,6 +47,9 @@ static const char* short_options = "V:h:p:U:P::n:s:b:K:k:o:Re:t:w:z:g:T:dL:SC:N:
 
 #define WARN_MSG 0x40000000
 
+// The C client's version string
+extern char *aerospike_client_version;
+
 /*
  * Identifies the TLS client command line options.
  */
@@ -274,6 +277,13 @@ benchmark_init(int argc, char* argv[])
 	else if (ret != -1) {
 		printf("Run with --help for usage information and flag options.\n");
 	}
+	else {
+		// return code was set to -1 when
+		// parsing help or version cases
+		// reset to 0 here to prevent a 
+		// failure return code
+		ret = 0;
+	}
 	_free_args(&args);
 	return ret;
 }
@@ -286,7 +296,10 @@ benchmark_init(int argc, char* argv[])
 LOCAL_HELPER void
 print_version()
 {
-	printf("asbench version 1.4.0\n");
+	fprintf(stdout, "Aerospike Benchmark Utility\n");
+	fprintf(stdout, "Version %s\n", TOOL_VERSION);
+	fprintf(stdout, "C Client Version %s\n", aerospike_client_version);
+	fprintf(stdout, "Copyright 2015-2021 Aerospike. All rights reserved.\n");
 }
 
 LOCAL_HELPER void

--- a/src/main/benchmark_init.c
+++ b/src/main/benchmark_init.c
@@ -299,7 +299,7 @@ print_version()
 	fprintf(stdout, "Aerospike Benchmark Utility\n");
 	fprintf(stdout, "Version %s\n", TOOL_VERSION);
 	fprintf(stdout, "C Client Version %s\n", aerospike_client_version);
-	fprintf(stdout, "Copyright 2015-2021 Aerospike. All rights reserved.\n");
+	fprintf(stdout, "Copyright 2015-2022 Aerospike. All rights reserved.\n");
 }
 
 LOCAL_HELPER void

--- a/src/test/integration/test_help.py
+++ b/src/test/integration/test_help.py
@@ -1,0 +1,6 @@
+
+import lib
+
+def test_help_long():
+	# test that the help command return code is 0
+	lib.run_benchmark(["--help"])

--- a/src/test/integration/test_version.py
+++ b/src/test/integration/test_version.py
@@ -1,0 +1,11 @@
+
+import lib
+
+def test_version_long():
+	# test that the version command return code is 0
+	lib.run_benchmark(["--version"])
+
+
+def test_version_short():
+	# test that the version command return code is 0
+	lib.run_benchmark(["-v"])


### PR DESCRIPTION

Key | Summary |
|-- | -- | 
  TOOLS-2125 | (ASBENCH) Running --version exits with return code 255. |
  TOOLS-2122 | (ASBENCH) Reported version is incorrect for asbench 1.5. |
  TOOLS-2144 | (ASBENCH) Align --version output with asadm and asinfo. |


[TOOLS-2144](https://aerospike.atlassian.net/browse/TOOLS-2144)	
[(ASBENCH) Align --version output with asadm and asinfo.](https://aerospike.atlassian.net/browse/TOOLS-2144)

Bug	[TOOLS-2125](https://aerospike.atlassian.net/browse/TOOLS-2125)	
[(ASBENCH) Running --version exits with return code 255.](https://aerospike.atlassian.net/browse/TOOLS-2125)

[asbenchmark](https://aerospike.atlassian.net/issues/?jql=project+%3D+TOOLS+AND+component+%3D+asbenchmark)	[Dylan Welch](https://aerospike.atlassian.net/secure/ViewProfile.jspa?accountId=5d49f88cc701730c804e0554)	Minor	BACKLOG	24/Aug/22
Bug	[TOOLS-2122](https://aerospike.atlassian.net/browse/TOOLS-2122)	
[(ASBENCH) Reported version is incorrect for asbench 1.5.](https://aerospike.atlassian.net/browse/TOOLS-2122)