### PR TITLE
fix: TOOLS-2961 Warning should be based transaction_worker_threads and not on n_threads

### DIFF
--- a/src/main/benchmark_init.c
+++ b/src/main/benchmark_init.c
@@ -1861,7 +1861,7 @@ _load_defaults(args_t* args)
 	args->set = "testset";
 	args->bin_name = strdup("testbin");
 	args->start_key = 1;
-	args->keys = 1000008;
+	args->keys = 1000000;
 	memset(&args->stage_defs, 0, sizeof(struct stage_defs_s));
 	args->workload_stages_file = NULL;
 	obj_spec_parse(&args->obj_spec, "I");

--- a/src/main/benchmark_init.c
+++ b/src/main/benchmark_init.c
@@ -1861,7 +1861,7 @@ _load_defaults(args_t* args)
 	args->set = "testset";
 	args->bin_name = strdup("testbin");
 	args->start_key = 1;
-	args->keys = 1000000;
+	args->keys = 1000008;
 	memset(&args->stage_defs, 0, sizeof(struct stage_defs_s));
 	args->workload_stages_file = NULL;
 	obj_spec_parse(&args->obj_spec, "I");

--- a/src/main/coordinator.c
+++ b/src/main/coordinator.c
@@ -124,6 +124,7 @@ coordinator_worker(void* udata)
 	cdata_t* cdata = args->cdata;
 	tdata_t** tdatas = args->tdatas;
 	uint32_t n_threads = args->n_threads;
+	uint32_t worker_threads = args->cdata->transaction_worker_threads;
 	as_random random;
 
 	uint32_t n_stages = cdata->stages.n_stages;
@@ -145,12 +146,12 @@ coordinator_worker(void* udata)
 				}
 			}
 			else { // TODO when async is multithreaded change this
-				if (stage->batch_write_size * n_threads > nkeys) {
+				if (stage->batch_write_size * worker_threads > nkeys) {
 					blog_warn("--batch-write-size * --threads is greater than --keys so "
 								"more than --keys records will be written\n");
 				}
 
-				if (nkeys % (stage->batch_write_size * n_threads) != 0) {
+				if (nkeys % (stage->batch_write_size * worker_threads) != 0) {
 					blog_warn("--keys is not divisible by (--batch-write-size * --threads) so more than "
 								"--keys records will be written\n");
 				}
@@ -167,12 +168,12 @@ coordinator_worker(void* udata)
 				}
 			}
 			else { // TODO when async is multithreaded change this
-				if (stage->batch_delete_size * n_threads > nkeys) {
+				if (stage->batch_delete_size * worker_threads > nkeys) {
 					blog_warn("--batch-delete-size * --threads is greater than --keys so more than "
 								"--keys records will be deleted\n");
 				}
 
-				if (nkeys % (stage->batch_delete_size * n_threads) != 0) {
+				if (nkeys % (stage->batch_delete_size * worker_threads) != 0) {
 					blog_warn("--keys is not divisible by (--batch-delete-size * --threads) so more than "
 								"--keys records will be deleted\n");
 				}


### PR DESCRIPTION
The Transaction workers considered at https://github.com/aerospike/aerospike-benchmark/blob/3e49d3cf2a8e3b25004729398c5936cf06734224/src/main/coordinator.c#L126 which is transaction_workers + 1 [1 logging thread - 16 worker threads].
https://github.com/aerospike/aerospike-benchmark/blob/3e49d3cf2a8e3b25004729398c5936cf06734224/src/main/benchmark.c#L414

To fix the default warning of 
`WARN --keys is not divisible by (--batch-write-size * --threads) so more than --keys records will be written`

setting the warning logic based on `transaction_worker_threads` and not using `n_threads`
