### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "modules/libcyaml"]
 	path = modules/libcyaml
-	url = git@github.com:aerospike/libcyaml.git
+	url = https://github.com/aerospike/libcyaml.git
 [submodule "modules/c-client"]
 	path = modules/c-client
-	url = git@github.com:aerospike/aerospike-client-c.git
+	url = https://github.com/aerospike/aerospike-client-c.git
 [submodule "modules/libyaml"]
 	path = modules/libyaml
-	url = git@github.com:yaml/libyaml.git
+	url = https://github.com/yaml/libyaml.git


### PR DESCRIPTION
This patch (switching to HTTPS) will allow building without ssh access so the user can update the submodules. If this isn't a desired patch, then the README should be updated to edit .git/config after cloning.