### PR TITLE
Don't crash when --output-file can't be opened

### DIFF
--- a/src/main/latency_output.c
+++ b/src/main/latency_output.c
@@ -47,8 +47,7 @@ initialize_histograms(cdata_t* cdata, args_t* args, time_t* start_time,
 			if (!cdata->histogram_output) {
 				fprintf(stderr, "Unable to open %s in append mode\n",
 						args->histogram_output);
-				ret = -1;
-				// follow through with initialization, so cleanup won't segfault
+				return -1;
 			}
 		}
 		else {

--- a/src/main/latency_output.c
+++ b/src/main/latency_output.c
@@ -25,7 +25,6 @@
 int
 initialize_histograms(cdata_t* cdata, args_t* args, time_t* start_time,
 		hdr_timespec* start_timespec) {
-	int ret = 0;
 	bool has_writes = stages_contain_writes(&cdata->stages);
 	bool has_reads = stages_contain_reads(&cdata->stages);
 	bool has_udfs = stages_contain_udfs(&cdata->stages);
@@ -121,14 +120,14 @@ initialize_histograms(cdata_t* cdata, args_t* args, time_t* start_time,
 			if (!cdata->hdr_comp_write_output) {
 				fprintf(stderr, "Unable to open %s in append mode, reason: %s\n",
 						cmp_write_output_b.data, strerror(errno));
-				ret = -1;
+				return -1;
 			}
 
 			cdata->hdr_text_write_output = fopen(txt_write_output_b.data, "a");
 			if (!cdata->hdr_text_write_output) {
 				fprintf(stderr, "Unable to open %s in append mode, reason: %s\n",
 						cmp_write_output_b.data, strerror(errno));
-				ret = -1;
+				return -1;
 			}
 
 			as_string_builder_destroy(&cmp_write_output_b);
@@ -159,14 +158,14 @@ initialize_histograms(cdata_t* cdata, args_t* args, time_t* start_time,
 			if (!cdata->hdr_comp_read_output) {
 				fprintf(stderr, "Unable to open %s in append mode, reason: %s\n",
 						cmp_read_output_b.data, strerror(errno));
-				ret = -1;
+				return -1;
 			}
 
 			cdata->hdr_text_read_output = fopen(txt_read_output_b.data, "a");
 			if (!cdata->hdr_text_read_output) {
 				fprintf(stderr, "Unable to open %s in append mode, reason: %s\n",
 						cmp_read_output_b.data, strerror(errno));
-				ret = -1;
+				return -1;
 			}
 
 			as_string_builder_destroy(&cmp_read_output_b);
@@ -197,14 +196,14 @@ initialize_histograms(cdata_t* cdata, args_t* args, time_t* start_time,
 			if (!cdata->hdr_comp_udf_output) {
 				fprintf(stderr, "Unable to open %s in append mode, reason: %s\n",
 						cmp_udf_output_b.data, strerror(errno));
-				ret = -1;
+				return -1;
 			}
 
 			cdata->hdr_text_udf_output = fopen(txt_udf_output_b.data, "a");
 			if (!cdata->hdr_text_udf_output) {
 				fprintf(stderr, "Unable to open %s in append mode, reason: %s\n",
 						cmp_udf_output_b.data, strerror(errno));
-				ret = -1;
+				return -1;
 			}
 
 			as_string_builder_destroy(&cmp_udf_output_b);
@@ -225,7 +224,7 @@ initialize_histograms(cdata_t* cdata, args_t* args, time_t* start_time,
 			hdr_init(1, 1000000, 3, &cdata->udf_hdr);
 		}
 	}
-	return ret;
+	return 0;
 }
 
 void

--- a/src/test/integration/test_output_file.py
+++ b/src/test/integration/test_output_file.py
@@ -1,0 +1,30 @@
+import lib
+import subprocess
+import signal
+
+
+def test_output_file_unopenable():
+    """
+    When --output-file is given a path that can't be opened, asbench should exit
+    with an error rather than crashing with a segfault.
+    """
+    lib.start()
+    directory = lib.absolute_path("../../..")
+
+    cmd = [
+        "test_target/asbench",
+        "-h",
+        f"{lib.SERVER_IP}:{lib.PORT}",
+        "-n",
+        lib.NAMESPACE,
+        "-s",
+        lib.SET,
+        "--output-file",
+        ".",
+    ]
+
+    result = subprocess.run(cmd, cwd=directory)
+
+    assert result.returncode != 0, "expected non-zero exit code"
+    assert result.returncode != -signal.SIGSEGV, "crashed with SIGSEGV"
+    assert result.returncode > 0, "killed by signal %d instead of exiting" % (-result.returncode)


### PR DESCRIPTION
There was a segfault here, trying to print to a null file pointer. For example:

```
$ gdb --args asbench --output-file "."
[...]
Unable to open . in append mode

Thread 1 "asbench" received signal SIGSEGV, Segmentation fault.
0x00007ffff7c6b531 in __vfprintf_internal (s=0x0, 
    format=0x5555559b3f78 "%s:\n\tTotal num buckets: %u\n\tRange min: %luus\n\tRange max: %luus\n", ap=ap@entry=0x7fffffffc0c0, 
    mode_flags=2) at ./stdio-common/vfprintf-internal.c:1525
warning: 1525	./stdio-common/vfprintf-internal.c: No such file or directory
(gdb) bt
#0  0x00007ffff7c6b531 in __vfprintf_internal (s=0x0, 
    format=0x5555559b3f78 "%s:\n\tTotal num buckets: %u\n\tRange min: %luus\n\tRange max: %luus\n", ap=ap@entry=0x7fffffffc0c0, 
    mode_flags=2) at ./stdio-common/vfprintf-internal.c:1525
#1  0x00007ffff7d36cf3 in ___fprintf_chk (fp=<optimized out>, flag=<optimized out>, format=<optimized out>) at ./debug/fprintf_chk.c:33
#2  0x00005555555e0771 in histogram_print_info ()
#3  0x00005555555da138 in initialize_histograms ()
#4  0x00005555555e2a81 in run_benchmark ()
#5  0x00005555555d8524 in benchmark_init ()
#6  0x00007ffff7c2a1ca in __libc_start_call_main (main=main@entry=0x5555555d520b <main>, argc=argc@entry=21, 
    argv=argv@entry=0x7fffffffe168) at ../sysdeps/nptl/libc_start_call_main.h:58
#7  0x00007ffff7c2a28b in __libc_start_main_impl (main=0x5555555d520b <main>, argc=21, argv=0x7fffffffe168, init=<optimized out>, 
    fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffffffe158) at ../csu/libc-start.c:360
#8  0x00005555555d5245 in _start ()
```