### PR TITLE
ci(pkg): dynamic-dependency allowlist guard; declare rpm openssl-libs

### DIFF
--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+function assert_dynamic_deps() {
+	local allowed="libc.so.6 libm.so.6 libpthread.so.0 libdl.so.2 librt.so.1
+		libgcc_s.so.1 libz.so.1 ld-linux-x86-64.so.2 ld-linux-aarch64.so.1"
+	if [ "$ENV_DISTRO" = "el8" ] || [ "$ENV_DISTRO" = "debian11" ]; then
+		allowed+=" libssl.so.1.1 libcrypto.so.1.1"
+	else
+		allowed+=" libssl.so.3 libcrypto.so.3"
+	fi
+
+	local lib fail=0
+	local needed
+	needed=$(readelf -d target/asbench | awk '/\(NEEDED\)/ { gsub(/[][]/, "", $NF); print $NF }')
+	echo "asbench DT_NEEDED:" $needed
+	for lib in $needed; do
+		if ! printf '%s\n' $allowed | grep -qxF "$lib"; then
+			echo "asbench has unexpected dynamic dependency $lib; link it statically or add it to the allowlist and the package depends" >&2
+			fail=1
+		fi
+	done
+	return $fail
+}
+
 function build_packages() {
 	if [ "${ENV_DISTRO:-}" = "" ]; then
 		echo "ENV_DISTRO is not set" >&2
@@ -17,6 +39,8 @@ function build_packages() {
 	# Pass VERSION explicitly so the embedded TOOL_VERSION matches the package
 	# version, even when the git tag hasn't been pushed yet (tag-last pipeline).
 	make EVENT_LIB=libuv LIBUV_STATIC_PATH=/usr/local/lib VERSION="${VERSION}"
+
+	assert_dynamic_deps
 
 	# package
 	cd "$GIT_DIR"/pkg || exit 1

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -52,6 +52,7 @@ rpm: prep
 		--name $(NAME) \
 		--version $(RPM_VERSION) \
 		--maintainer $(MAINTAINER) \
+		--depends "openssl-libs" \
 		--description $(DESCRIPTION) \
 		--license $(LICENSE) \
 		--url $(URL) \


### PR DESCRIPTION
## Problem

asbench packages ship with **zero declared runtime dependencies** even though the binary dynamically links distro OpenSSL and zlib. fpm with dir input generates no automatic Depends (deb) and sets `AutoReqProv: no` (rpm), so dependency metadata is entirely manual, and nothing today stops a statically-linked lib from silently going dynamic (or a new dynamic dep from appearing undeclared). Same bug class as aerospike/aql#84 and aerospike/aerospike-tools-backup#164.

## Changes

- **.github/bin/build_package.sh**: `assert_dynamic_deps` gate between build and packaging. Dumps `DT_NEEDED` of `target/asbench` and fails on anything outside a per-distro allowlist (glibc family, libgcc_s, zlib, distro OpenSSL: 1.1 on el8/debian11, 3 elsewhere). Runs in every job of both build-and-release and the PR-time build-check.
- **pkg/Makefile**: rpm declares `--depends "openssl-libs"`, matching what the binary actually loads (libssl/libcrypto, not the openssl CLI).

## Linkage state (release matrix)

| Build env | static | dynamic (DT_NEEDED beyond glibc) |
|---|---|---|
| all 10 Linux distros × both arches | libuv v1.43.0 (source-built, `LIBUV_STATIC_PATH`), libyaml/libcyaml (vendored .a), c-client + Lua | libssl/libcrypto (distro), libz |
| macOS 14/15/26 | libuv + OpenSSL static | libz, libSystem only |

deb keeps no declared deps: libssl3/zlib1g naming varies per distro release (libssl1.1 on debian11, t64 renames on newer Ubuntu), and every deb-based target ships them in practice; the guard now pins the actual linkage so drift fails the build instead of shipping.

## Verification

- Guard logic validated against real ELF binaries in a container (flags unexpected NEEDED entries, passes glibc-only binaries).
- Dry-run Build and Release dispatch on this branch (release=false) to exercise the guard across the full matrix; results posted below.