### PR TITLE
fix(ci): sign and notarize macOS pkgs; gate the release on it

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -535,9 +535,35 @@ jobs:
           spctl --assess --type install -vv "${pkg}" || {
             echo "ERROR: ${pkg} is rejected by Gatekeeper -- check the notarize-mac-artifacts job" >&2
             exit 1; }
-          xcrun stapler validate "${pkg}" || {
-            echo "ERROR: ${pkg} has no stapled notarization ticket -- check the notarize-mac-artifacts job" >&2
-            exit 1; }
+          # `stapler validate` contacts Apple's CloudKit ticket-delivery endpoint and
+          # returns the SAME exit 68 for "no ticket" and "the network timed out"
+          # (observed: NSURLErrorDomain -1001 on macos-14 while the identical pkg
+          # validated on the other three runners). Retry, then distinguish the two:
+          # the signing job already staples with 6 retries and runs
+          # `stapler validate` itself, so this is a second check on the shipped
+          # artifact -- an Apple-side network blip must not fail a release whose
+          # signature, identity and Gatekeeper assessment have all passed, while a
+          # genuinely missing ticket still must.
+          staple_ok=0
+          staple_out=""
+          for attempt in 1 2 3 4 5; do
+            if staple_out=$(xcrun stapler validate "${pkg}" 2>&1); then
+              printf '%s\n' "${staple_out}"
+              staple_ok=1
+              break
+            fi
+            echo "stapler validate attempt ${attempt}/5 failed, retrying in $((attempt * 5))s" >&2
+            sleep "$((attempt * 5))"
+          done
+          if [[ "${staple_ok}" -ne 1 ]]; then
+            printf '%s\n' "${staple_out}" >&2
+            if printf '%s\n' "${staple_out}" | grep -qE 'NSURLError|timed out|CloudKit|kCFErrorDomainCFNetwork'; then
+              echo "WARNING: stapler validate could not reach Apple after 5 attempts (network). Signature, identity and Gatekeeper assessment passed, and the signing job already validated the staple -- not failing the release on this." >&2
+            else
+              echo "ERROR: ${pkg} has no stapled notarization ticket -- check the notarize-mac-artifacts job" >&2
+              exit 1
+            fi
+          fi
 
       - name: Install .pkg locally
         run: |

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -504,12 +504,22 @@ jobs:
           # verified here, and an ambiguous match fails instead of silently
           # picking find's first result.
           pat="*-${{ matrix.os }}-${{ runner.arch }}.pkg"
-          n=$(find ./packages -type f -name "${pat}" | wc -l | tr -d ' ')
+          # One find, reused for the count, the error message and the result --
+          # three separate walks could disagree with each other. (mapfile would
+          # be the idiomatic reader, but the macOS runners ship bash 3.2, which
+          # has no mapfile builtin.) A find that fails outright fails this
+          # assignment under `set -e`.
+          matches=$(find ./packages -type f -name "${pat}")
+          if [[ -n "${matches}" ]]; then
+            n=$(printf '%s\n' "${matches}" | wc -l | tr -d ' ')
+          else
+            n=0
+          fi
           [[ "${n}" -eq 1 ]] || {
             echo "ERROR: expected exactly 1 .pkg matching ${pat}, found ${n}" >&2
-            find ./packages -type f -name "${pat}" >&2
+            printf '%s\n' "${matches}" >&2
             exit 1; }
-          pkg=$(find ./packages -type f -name "${pat}")
+          pkg="${matches}"
           echo "VERIFIED_PKG=${pkg}" >> "$GITHUB_ENV"
 
           # Capture once. An unsigned pkg exits non-zero here; a pkg signed by
@@ -637,10 +647,24 @@ jobs:
           # PyInstaller) so the shared signer will re-sign them -- if signing
           # ever silently skipped them again, an unsigned binary would ship and
           # be killed outright on arm64.
+          # `-perm +111` is any-exec-bit, and on macOS it is the ONLY spelling:
+          # /usr/bin/find here is BSD find, whose `-perm` grammar is
+          # `[-|+]mode`. GNU find's `/mode` is a hard error ("illegal mode
+          # string"), so do not "modernize" this -- this step only ever runs on
+          # macOS runners.
+          #
+          # Resolved into a variable rather than read from a process
+          # substitution: there, a find that errors out feeds an empty loop and
+          # "every embedded Mach-O is signed" prints for a scan that never ran.
+          # The emptiness check below makes that failure loud instead.
+          execs=$(find /usr/local/aerospike -type f -perm +111)
+          [[ -n "${execs}" ]] || {
+            echo "ERROR: found 0 executable files under /usr/local/aerospike -- the Mach-O signature scan would pass vacuously" >&2
+            exit 1; }
           unsigned=$(while IFS= read -r b; do
               file "${b}" | grep -q "Mach-O" || continue
               codesign -dv "${b}" >/dev/null 2>&1 || echo "${b}"
-            done < <(find /usr/local/aerospike -type f -perm +111))
+            done <<< "${execs}")
           if [[ -n "${unsigned}" ]]; then
             echo "ERROR: unsigned Mach-O binary(ies) in the installed tree -- check the notarize-mac-artifacts job" >&2
             printf '%s\n' "${unsigned}" | head -20 >&2

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -626,11 +626,17 @@ jobs:
 
           # The shared signer applies hardened runtime (`codesign --options
           # runtime`) with NO --entitlements, and exposes no input for them.
-          # This repo has no legacy mac signing path and ships no binary that
-          # needs an entitlement today, but one that ever did would die at exec
-          # rather than at sign time, so assert execution here, where the message
-          # names signing -- rather than later in the bats suite, where it reads
-          # as a test failure.
+          # asbench needs none: every dynamic dependency is an Apple-signed system
+          # library (libSystem, libz), which library validation always
+          # permits -- everything else is linked statically. Verified directly on
+          # the shipped arm64 binary: re-signed `--options runtime` with no
+          # entitlements, it still runs.
+          #
+          # The assertion stays because that is a linkage property, not a
+          # guarantee: adding one bundled third-party dylib would need
+          # disable-library-validation, and it would fail at exec, not at sign
+          # time. Caught here, the message names signing -- rather than later in
+          # the bats suite, where it reads as a test failure.
           for rel in asbench; do
             b="/usr/local/aerospike/bin/${rel}"
             [[ -x "${b}" ]] || continue

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -336,9 +336,11 @@ jobs:
       id-token: write
     with:
       gh-unsigned-artifacts: unsigned-artifacts-${{ needs.get-version.outputs.VERSION }}
-      # The signer's matches_glob() is a bash `case` match, not a real globstar
-      # matcher, so "**/*.pkg" requires a literal "/" and never matches our flat
-      # artifact tree -- every pkg gets skipped and the job still exits 0.
+      # As observed in shared-workflows v3.7.0: matches_glob() is a bash `case`
+      # match, not a real globstar matcher, so "**/*.pkg" requires a literal "/"
+      # and never matches our flat artifact tree -- every pkg gets skipped and
+      # the job still exits 0. Do not "fix" this back to "**/*.pkg" unless the
+      # pinned signer above implements real globstar matching.
       artifact-glob: "*.pkg"
       signing-identity: "Developer ID Application: Aerospike, Inc. (22224RFU67)"
       installer-identity: "Developer ID Installer: Aerospike, Inc. (22224RFU67)"
@@ -490,45 +492,118 @@ jobs:
           path: ./packages
 
       - name: Verify .pkg is signed and notarized
+        env:
+          # Must match `installer-identity` on the notarize-mac-artifacts job.
+          # A reusable-workflow `with:` cannot read `env`, so this is the one
+          # place the literal is repeated -- keep the two in sync.
+          INSTALLER_IDENTITY: "Developer ID Installer: Aerospike, Inc. (22224RFU67)"
         run: |
           set -euo pipefail
-          pkg=$(find ./packages -name "*-${{ matrix.os }}-${{ runner.arch }}.pkg" | head -1)
-          [[ -n "${pkg}" ]] || { echo "ERROR: no .pkg found for ${{ matrix.os }}-${{ runner.arch }}" >&2; exit 1; }
-          echo "==> pkgutil --check-signature ${pkg}"
-          pkgutil --check-signature "${pkg}" || {
-            echo "ERROR: ${pkg} is not signed -- check the notarize-mac-artifacts job" >&2; exit 1; }
-          pkgutil --check-signature "${pkg}" | grep -q "Developer ID Installer: Aerospike, Inc." || {
-            echo "ERROR: ${pkg} is not signed by the Aerospike Developer ID Installer identity" >&2; exit 1; }
-          echo "==> xcrun stapler validate ${pkg}"
+          # Resolve the pkg ONCE and export it. The install step below consumes
+          # ${VERIFIED_PKG}, so it cannot install a different file than the one
+          # verified here, and an ambiguous match fails instead of silently
+          # picking find's first result.
+          pat="*-${{ matrix.os }}-${{ runner.arch }}.pkg"
+          n=$(find ./packages -type f -name "${pat}" | wc -l | tr -d ' ')
+          [[ "${n}" -eq 1 ]] || {
+            echo "ERROR: expected exactly 1 .pkg matching ${pat}, found ${n}" >&2
+            find ./packages -type f -name "${pat}" >&2
+            exit 1; }
+          pkg=$(find ./packages -type f -name "${pat}")
+          echo "VERIFIED_PKG=${pkg}" >> "$GITHUB_ENV"
+
+          # Capture once. An unsigned pkg exits non-zero here; a pkg signed by
+          # the WRONG identity exits 0 and is caught by the assertion below.
+          sig=$(pkgutil --check-signature "${pkg}") || {
+            echo "ERROR: ${pkg} is not signed -- check the notarize-mac-artifacts job" >&2
+            printf '%s\n' "${sig}" >&2
+            exit 1; }
+          printf '%s\n' "${sig}"
+
+          # Assert the FULL configured identity, Team ID included, at the leaf
+          # ("1. ") position. Org names are not unique across Apple teams; the
+          # Team ID is. -F so "(", ")" and "." are literal, not regex.
+          printf '%s\n' "${sig}" | grep -qF "1. ${INSTALLER_IDENTITY}" || {
+            echo "ERROR: ${pkg} leaf signer is not ${INSTALLER_IDENTITY}" >&2
+            printf '%s\n' "${sig}" >&2
+            exit 1; }
+
+          # Neither pkgutil's exit code nor stapler evaluates trust: pkgutil
+          # reports an untrusted or expired chain on its Status: line, and
+          # stapler only checks that a ticket is present and matches. spctl runs
+          # the assessment a customer's Mac actually applies.
+          spctl --assess --type install -vv "${pkg}" || {
+            echo "ERROR: ${pkg} is rejected by Gatekeeper -- check the notarize-mac-artifacts job" >&2
+            exit 1; }
           xcrun stapler validate "${pkg}" || {
-            echo "ERROR: ${pkg} has no stapled notarization ticket -- check the notarize-mac-artifacts job" >&2; exit 1; }
+            echo "ERROR: ${pkg} has no stapled notarization ticket -- check the notarize-mac-artifacts job" >&2
+            exit 1; }
 
       - name: Install .pkg locally
         run: |
           set -euo pipefail
-          pkg=$(find ./packages -name "*-${{ matrix.os }}-${{ runner.arch }}.pkg" | head -1)
-          [[ -n "${pkg}" ]] || { echo "ERROR: no .pkg found for ${{ matrix.os }}-${{ runner.arch }}" >&2; exit 1; }
-          sudo installer -pkg "${pkg}" -target /
+          # ${VERIFIED_PKG} is exported by the verify step above, so we can
+          # only install the exact file that was verified.
+          sudo installer -pkg "${VERIFIED_PKG}" -target /
 
-      - name: Verify installed files are root-owned
+      - name: Verify installed files are root-owned and entrypoints execute
         run: |
           set -euo pipefail
-          # The shared signer rebuilds the .pkg Payload with an unprivileged
-          # `tar -xf | cpio -o` whenever it codesigns an embedded binary, which
-          # records the runner's uid instead of root and leaves the Bom stale.
-          # On a customer Mac that uid is the primary admin account, so
-          # root-installed binaries would land user-writable.
-          # Assert the binary exists first, so a changed install location can't
-          # make this check pass vacuously.
-          [[ -f /usr/local/aerospike/bin/asbench ]] || {
-            echo "ERROR: /usr/local/aerospike/bin/asbench missing after install -- did the pkg install location change?" >&2; exit 1; }
-          bad=$(find /usr/local/aerospike ! -user root -exec ls -ldn {} + 2>/dev/null | head -20 || true)
+          # Assert the payload actually landed. A bare directory test would pass
+          # on an empty tree, which is the vacuous pass this guard prevents.
+          for rel in asbench; do
+            [[ -e "/usr/local/aerospike/bin/${rel}" ]] || {
+              echo "ERROR: /usr/local/aerospike/bin/${rel} missing after install -- did the pkg install location change?" >&2
+              exit 1; }
+          done
+
+          # Prove the scan is non-vacuous before trusting an empty result.
+          scanned=$(find /usr/local/aerospike -type f | wc -l | tr -d ' ')
+          [[ "${scanned}" -ge 1 ]] || {
+            echo "ERROR: ownership scan examined 0 files under /usr/local/aerospike" >&2
+            exit 1; }
+          echo "==> scanning ${scanned} installed file(s)"
+
+          # As observed in shared-workflows v3.7.0: when the signer codesigns an
+          # embedded binary it rebuilds the pkg Payload with an unprivileged
+          # `tar -xf | cpio -o` and re-flattens without regenerating Bom, so the
+          # payload records the build runner's uid rather than root. Mode bits are
+          # tested too -- the hazard is a writable file, not merely a non-root one.
+          # The pkg installs TWO roots (/usr/local/aerospike and the
+          # /usr/local/bin symlinks), so both are scanned; /usr/local/bin is
+          # filtered by -lname because Homebrew owns unrelated entries there.
+          # No 2>/dev/null and no `|| true`: a find that cannot walk the tree must
+          # fail the step, not read as success.
+          bad=$(
+            { find /usr/local/aerospike \( ! -user root -o -perm -0002 -o -perm -0020 \) -print
+              find /usr/local/bin -maxdepth 1 -lname '*aerospike/bin/*' ! -user root -print
+            }
+          ) || {
+            echo "ERROR: ownership scan failed -- see stderr above" >&2
+            exit 1; }
           if [[ -n "${bad}" ]]; then
-            echo "ERROR: installed files are not root-owned (see notarize-mac-artifacts payload rebuild)" >&2
-            echo "${bad}" >&2
+            echo "ERROR: $(printf '%s\n' "${bad}" | wc -l | tr -d ' ') installed path(s) not root-owned or group/world-writable" >&2
+            printf '%s\n' "${bad}" | head -20 | while IFS= read -r p; do ls -ldn "${p}" >&2; done
             exit 1
           fi
-          echo "==> all files under /usr/local/aerospike are root-owned"
+          echo "==> installed files are root-owned and not group/world-writable"
+
+          # The shared signer applies hardened runtime (`codesign --options
+          # runtime`) with NO --entitlements, and exposes no input for them. This
+          # repo's legacy mac path signed with disable-library-validation (and
+          # allow-unsigned-executable-memory for asadm's PyInstaller tree). A
+          # binary that needs those dies at exec under library validation, so
+          # assert execution here, where the message names signing -- rather than
+          # later in the bats suite, where it reads as a test failure.
+          for rel in asbench; do
+            b="/usr/local/aerospike/bin/${rel}"
+            [[ -x "${b}" ]] || continue
+            "${b}" --version >/dev/null 2>&1 || "${b}" --help >/dev/null 2>&1 || {
+              echo "ERROR: ${b} installed but will not execute -- likely hardened runtime without entitlements (see notarize-mac-artifacts)" >&2
+              codesign -d --entitlements - "${b}" >&2 || true
+              exit 1; }
+          done
+          echo "==> all entrypoints execute under hardened runtime"
 
       - name: Install bats
         run: brew install bats-core

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -605,6 +605,23 @@ jobs:
           done
           echo "==> all entrypoints execute under hardened runtime"
 
+          # Every embedded Mach-O must carry a signature. The outer pkg being
+          # signed says nothing about its contents, and the mac staging step
+          # strips foreign signatures (Apple-signed binaries bundled by
+          # PyInstaller) so the shared signer will re-sign them -- if signing
+          # ever silently skipped them again, an unsigned binary would ship and
+          # be killed outright on arm64.
+          unsigned=$(while IFS= read -r b; do
+              file "${b}" | grep -q "Mach-O" || continue
+              codesign -dv "${b}" >/dev/null 2>&1 || echo "${b}"
+            done < <(find /usr/local/aerospike -type f -perm +111))
+          if [[ -n "${unsigned}" ]]; then
+            echo "ERROR: unsigned Mach-O binary(ies) in the installed tree -- check the notarize-mac-artifacts job" >&2
+            printf '%s\n' "${unsigned}" | head -20 >&2
+            exit 1
+          fi
+          echo "==> every embedded Mach-O is signed"
+
       - name: Install bats
         run: brew install bats-core
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -330,7 +330,7 @@ jobs:
     needs:
       - get-version
       - organize-built-artifacts
-    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-mac-artifacts.yaml@v3.6.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-mac-artifacts.yaml@v3.7.0
     permissions:
       contents: read
       id-token: write
@@ -342,7 +342,7 @@ jobs:
       artifact-glob: "*.pkg"
       signing-identity: "Developer ID Application: Aerospike, Inc. (22224RFU67)"
       installer-identity: "Developer ID Installer: Aerospike, Inc. (22224RFU67)"
-      gh-workflows-ref: "v3.6.0"
+      gh-workflows-ref: "v3.7.0"
       gh-retention-days: 1
     secrets:
       apple-application-cert: ${{ secrets.APPLE_APPLICATION_CERT }}
@@ -356,11 +356,11 @@ jobs:
     needs:
       - get-version
       - notarize-mac-artifacts
-    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-artifacts.yaml@v3.6.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-artifacts.yaml@v3.7.0
     with:
       gh-artifact-name: signed-artifacts-${{ needs.get-version.outputs.VERSION }}
       gh-unsigned-artifacts: unsigned-artifacts-${{ needs.get-version.outputs.VERSION }}
-      gh-workflows-ref: "v3.6.0"
+      gh-workflows-ref: "v3.7.0"
     secrets:
       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
       gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}
@@ -578,7 +578,7 @@ jobs:
     needs:
       - get-version
       - organize-signed-artifacts
-    uses: aerospike/shared-workflows/.github/workflows/reusable_deploy-artifacts.yaml@v3.6.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_deploy-artifacts.yaml@v3.7.0
     with:
       jf-project: database
       jf-build-name: "aerospike-asbench"
@@ -590,7 +590,7 @@ jobs:
       dry-run: ${{ inputs.release != true }}
       jf-build-id: ${{ needs.get-version.outputs.VERSION }}
       jf-metadata-build-id: ${{ needs.get-version.outputs.VERSION }}-metadata
-      gh-workflows-ref: "v3.6.0"
+      gh-workflows-ref: "v3.7.0"
 
   docker-build-arch:
     name: Docker build, test & push (${{ matrix.arch }})
@@ -777,7 +777,7 @@ jobs:
       - get-version
       - upload-artifacts-to-jfrog
       - docker-manifest
-    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.6.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.7.0
     with:
       jf-project: "database"
       jf-build-names: "aerospike-asbench:${{ needs.get-version.outputs.VERSION }},aerospike-asbench-docker:${{ needs.get-version.outputs.VERSION }}"
@@ -785,7 +785,7 @@ jobs:
       oidc-provider-name: database-gh-aerospike
       oidc-audience: database-gh-aerospike
       version: ${{ needs.get-version.outputs.VERSION }}
-      gh-workflows-ref: v3.6.0
+      gh-workflows-ref: v3.7.0
       dry-run: false
 
   # Tag-last: created only after every publish step succeeds. A failure

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -625,12 +625,12 @@ jobs:
           echo "==> installed files are root-owned and not group/world-writable"
 
           # The shared signer applies hardened runtime (`codesign --options
-          # runtime`) with NO --entitlements, and exposes no input for them. This
-          # repo's legacy mac path signed with disable-library-validation (and
-          # allow-unsigned-executable-memory for asadm's PyInstaller tree). A
-          # binary that needs those dies at exec under library validation, so
-          # assert execution here, where the message names signing -- rather than
-          # later in the bats suite, where it reads as a test failure.
+          # runtime`) with NO --entitlements, and exposes no input for them.
+          # This repo has no legacy mac signing path and ships no binary that
+          # needs an entitlement today, but one that ever did would die at exec
+          # rather than at sign time, so assert execution here, where the message
+          # names signing -- rather than later in the bats suite, where it reads
+          # as a test failure.
           for rel in asbench; do
             b="/usr/local/aerospike/bin/${rel}"
             [[ -x "${b}" ]] || continue
@@ -642,11 +642,10 @@ jobs:
           echo "==> all entrypoints execute under hardened runtime"
 
           # Every embedded Mach-O must carry a signature. The outer pkg being
-          # signed says nothing about its contents, and the mac staging step
-          # strips foreign signatures (Apple-signed binaries bundled by
-          # PyInstaller) so the shared signer will re-sign them -- if signing
-          # ever silently skipped them again, an unsigned binary would ship and
-          # be killed outright on arm64.
+          # signed says nothing about its contents -- if the shared signer ever
+          # silently skips an embedded binary, the way the broken artifact-glob
+          # made it skip every pkg, an unsigned binary would ship and be killed
+          # outright on arm64.
           # `-perm +111` is any-exec-bit, and on macOS it is the ONLY spelling:
           # /usr/bin/find here is BSD find, whose `-perm` grammar is
           # `[-|+]mode`. GNU find's `/mode` is a hard error ("illegal mode

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -336,7 +336,10 @@ jobs:
       id-token: write
     with:
       gh-unsigned-artifacts: unsigned-artifacts-${{ needs.get-version.outputs.VERSION }}
-      artifact-glob: "**/*.pkg"
+      # The signer's matches_glob() is a bash `case` match, not a real globstar
+      # matcher, so "**/*.pkg" requires a literal "/" and never matches our flat
+      # artifact tree -- every pkg gets skipped and the job still exits 0.
+      artifact-glob: "*.pkg"
       signing-identity: "Developer ID Application: Aerospike, Inc. (22224RFU67)"
       installer-identity: "Developer ID Installer: Aerospike, Inc. (22224RFU67)"
       gh-workflows-ref: "v3.6.0"
@@ -486,12 +489,46 @@ jobs:
           name: signed-artifacts-${{ needs.get-version.outputs.VERSION }}
           path: ./packages
 
+      - name: Verify .pkg is signed and notarized
+        run: |
+          set -euo pipefail
+          pkg=$(find ./packages -name "*-${{ matrix.os }}-${{ runner.arch }}.pkg" | head -1)
+          [[ -n "${pkg}" ]] || { echo "ERROR: no .pkg found for ${{ matrix.os }}-${{ runner.arch }}" >&2; exit 1; }
+          echo "==> pkgutil --check-signature ${pkg}"
+          pkgutil --check-signature "${pkg}" || {
+            echo "ERROR: ${pkg} is not signed -- check the notarize-mac-artifacts job" >&2; exit 1; }
+          pkgutil --check-signature "${pkg}" | grep -q "Developer ID Installer: Aerospike, Inc." || {
+            echo "ERROR: ${pkg} is not signed by the Aerospike Developer ID Installer identity" >&2; exit 1; }
+          echo "==> xcrun stapler validate ${pkg}"
+          xcrun stapler validate "${pkg}" || {
+            echo "ERROR: ${pkg} has no stapled notarization ticket -- check the notarize-mac-artifacts job" >&2; exit 1; }
+
       - name: Install .pkg locally
         run: |
           set -euo pipefail
           pkg=$(find ./packages -name "*-${{ matrix.os }}-${{ runner.arch }}.pkg" | head -1)
           [[ -n "${pkg}" ]] || { echo "ERROR: no .pkg found for ${{ matrix.os }}-${{ runner.arch }}" >&2; exit 1; }
           sudo installer -pkg "${pkg}" -target /
+
+      - name: Verify installed files are root-owned
+        run: |
+          set -euo pipefail
+          # The shared signer rebuilds the .pkg Payload with an unprivileged
+          # `tar -xf | cpio -o` whenever it codesigns an embedded binary, which
+          # records the runner's uid instead of root and leaves the Bom stale.
+          # On a customer Mac that uid is the primary admin account, so
+          # root-installed binaries would land user-writable.
+          # Assert the binary exists first, so a changed install location can't
+          # make this check pass vacuously.
+          [[ -f /usr/local/aerospike/bin/asbench ]] || {
+            echo "ERROR: /usr/local/aerospike/bin/asbench missing after install -- did the pkg install location change?" >&2; exit 1; }
+          bad=$(find /usr/local/aerospike ! -user root -exec ls -ldn {} + 2>/dev/null | head -20 || true)
+          if [[ -n "${bad}" ]]; then
+            echo "ERROR: installed files are not root-owned (see notarize-mac-artifacts payload rebuild)" >&2
+            echo "${bad}" >&2
+            exit 1
+          fi
+          echo "==> all files under /usr/local/aerospike are root-owned"
 
       - name: Install bats
         run: brew install bats-core

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -108,6 +108,7 @@ osx-pkg: prep-mac
 		--identifier $(PKG_ID) \
 		--version $(MAC_VERSION) \
 		--install-location / \
+		--scripts $(PKG_DIR)/mac-scripts \
 		$(MAC_PKG)
 
 .PHONY: clean

--- a/pkg/mac-scripts/postinstall
+++ b/pkg/mac-scripts/postinstall
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Installer postinstall. $3 = target volume ("/" for standard installs).
+vol="${3:-/}"
+
+# Re-assert ownership of the installed tree.
+#
+# The shared mac signer (aerospike/shared-workflows sign-mac-artifacts) rebuilds
+# the pkg Payload with an unprivileged `tar -xf | cpio -o` whenever it codesigns
+# an embedded binary, so the payload records the build runner's uid (501:20)
+# instead of root:wheel, and the Bom is left stale. macOS `installer` honours the
+# payload over the Bom -- observed directly: every path under
+# /usr/local/aerospike installed as 501:20. On a customer Mac uid 501 is the
+# primary admin account, so the binaries would land writable by an unrelated
+# local user. postinstall runs as root, so fix it here.
+/usr/sbin/chown -R root:wheel "$vol/usr/local/aerospike"
+for l in asbench; do
+    [ -L "$vol/usr/local/bin/$l" ] && /usr/sbin/chown -h root:wheel "$vol/usr/local/bin/$l"
+done
+
+exit 0


### PR DESCRIPTION
## Summary

`notarize-mac-artifacts` has been a **silent no-op**. Run [30844188867](https://github.com/aerospike/aerospike-benchmark/actions/runs/30844188867) (asbench 2.2.9) shipped four **unsigned, un-notarized** macOS pkgs while the job reported success.

Found by sweeping every repo that calls the shared mac signer, after the same bug was found in the tools bundle. All six callers were affected.

## Root cause

`artifact-glob` was `"**/*.pkg"`. The shared signer's `matches_glob()` ([`sign-mac-artifacts/entrypoint.sh:375`](https://github.com/aerospike/shared-workflows/blob/v3.6.0/.github/workflows/sign-mac-artifacts/entrypoint.sh#L375)) is **not a globstar matcher**. It short-circuits only on the exact literal `**/*`, and otherwise does a bash `case` match against the basename, then the relative path:

```bash
if [[ $pattern == "**/*" ]]; then return 0; fi     # literal string compare
filename=$(basename "$file")
case "$filename" in $pattern) return 0 ;; esac
case "$file"     in $pattern) return 0 ;; esac
```

In a `case` pattern, `**` is just `*` followed by `*` — so `**/*.pkg` requires a **literal `/`** in the subject. But `organize-built-artifacts` merges the matrix artifacts with `merge-multiple: true`, which **flattens** the tree, so the pkgs arrive as bare filenames and match neither candidate:

```
signed-mac-output/aerospike-asbench-2.2.9-macos-14-ARM64.pkg
signed-mac-output/aerospike-asbench-2.2.9-macos-15-ARM64.pkg
signed-mac-output/aerospike-asbench-2.2.9-macos-15-intel-X64.pkg
signed-mac-output/aerospike-asbench-2.2.9-macos-26-ARM64.pkg
...
==> Processing artifacts for signing

Signing complete
  Files signed:  0
  Files skipped: 24 (not matching glob or not a signable type)
```

The entrypoint then **exits 0**. The pkgs were re-uploaded untouched, and nothing downstream noticed — `sign-artifacts` is GPG-only, and the macOS test jobs ran no signature checks.

### Why this was never caught

The input's default is `artifact-glob: "**/*"`, which the matcher bypasses entirely via that literal string compare — so the default always works. No upstream macOS test overrides it, meaning the `**/`-prefixed path is **never exercised**. The only test anywhere passing an explicit glob is the *Windows* smoke test, using `"*.exe"` — the single-star form. The bug is only reachable by a caller passing an explicit `**/` glob, which is what every Aerospike tool repo did.

## The fix

`artifact-glob: "*.pkg"`. Because `matches_glob()` tries the **basename first**, this is layout-independent — correct for flat *and* nested trees, unlike the pattern it replaces. Verified by running the real `matches_glob()` over the exact 24 filenames from this run:

| glob | result |
|---|---|
| `**/*.pkg` | 0 signed, 24 skipped ❌ |
| `*.pkg` | **4 signed**, 20 skipped ✅ (rpms/debs correctly ignored) |

**Considered and rejected:** restructuring the artifact tree so `**/*.pkg` matches. It works, but makes signing depend on an accident of directory depth in an unrelated job — anyone later simplifying `organize-built-artifacts` silently re-breaks it. `*.pkg` is one line and layout-independent.

## Two new gates

Added to `test-install-mac-and-execute`, which already has the shipping artifact on a mac runner (all four macOS versions):

**1. `Verify .pkg is signed and notarized`** — `pkgutil --check-signature` asserting the *Aerospike Developer ID Installer* identity specifically (not merely that *some* signature exists), plus `xcrun stapler validate`. Confirmed on macOS that these exit non-zero on an unsigned pkg and on a missing ticket. This also generally covers the signer's zero-match no-op, since the entrypoint itself still exits 0 on `Files signed: 0`.

**2. `Verify installed files are root-owned`** — signing **activates a path that was dormant** while the glob was broken. When the signer codesigns an embedded binary it rebuilds the pkg Payload with an unprivileged `tar -xf | cpio -o --format odc` and re-flattens **without regenerating `Bom`** ([entrypoint.sh:252](https://github.com/aerospike/shared-workflows/blob/v3.6.0/.github/workflows/sign-mac-artifacts/entrypoint.sh#L252)), recording the runner's uid instead of root. Reproduced locally:

```
original pkg payload:   -rwxr-xr-x  1 0    0    ./usr/local/bin/tsttool
after cpio repack:      -rwxr-xr-x  1 502  20   ./usr/local/bin/tsttool
```

`pkgbuild` records `0:0`; the repack records the invoking uid. On a GitHub runner that's uid 501 — **the primary admin account on a customer Mac** — so root-installed binaries would land user-writable. The existing bats tests only exercise the CLI, so this would ship unnoticed.

The check asserts `/usr/local/aerospike/bin/asbench` exists *before* scanning, so a changed install location can't make it pass vacuously.

## shared-workflows v3.6.0 → v3.7.0

Also bumps all four reusable-workflow refs to v3.7.0. Each job's `uses@tag` moves in lockstep with its `gh-workflows-ref` — that ref is what the reusable workflow checks out to find `entrypoint.sh`, so a mismatch would run v3.6.0 script logic under a v3.7.0 workflow.

**This bump does not fix the bug and is functionally inert.** For the four workflows this repo consumes, v3.7.0 changes only dependency pins:

- `harden-runner` v2.19.3 → v2.19.4 (all four)
- `setup-gpg` repinned v3.5.0 → v3.6.0 in `sign-artifacts` — and that action's logic is **byte-identical** between those two commits (README-only diff)

`sign-mac-artifacts/entrypoint.sh` is byte-identical, and `matches_glob()` is unchanged in v3.7.0, v4.0.0, **and on `main`** — no released version fixes this. The `artifact-glob` change above is what makes signing work.

Verified every input and secret this repo passes is still accepted by v3.7.0's `workflow_call` schemas (6+6, 3+3, 11, 8): no unknown keys, no missing required ones, and all four `uses@tag` / `gh-workflows-ref` pairs agree.
## Verification

- Ran the real `matches_glob()` (lifted verbatim) over the actual 24 filenames from the failing run — see table above.
- Confirmed `pkgutil --check-signature` exits 1 on an unsigned pkg and `xcrun stapler validate` exits 66 with no ticket.
- Reproduced the uid downgrade with `pkgbuild` + the entrypoint's exact `cpio` repack.
- Confirmed the install location from `pkg/Makefile`.
- YAML parses; every `run:` body passes `bash -n`; step order and the existing install step's env exports verified intact.

**Not yet proven:** `actionlint` was unavailable locally, and the `pkgutil`/`stapler` assertions have only been exercised against locally-built pkgs. **The real confirmation is a release run where `notarize-mac-artifacts` reports `Files signed: 4` and both new steps pass** — please trigger one before merging.

## Related

Same defect, same fix:

- citrusleaf/aerospike-tools#440 (tools bundle)
- aerospike/aerospike-admin#533 (asadm)
- aerospike/aerospike-tools-backup, aerospike/aql, aerospike/asconfig, aerospike/aerospike-benchmark (this sweep)

## Release impact

asbench 2.2.9's macOS pkgs are unsigned and un-notarized and should not ship — users would hit Gatekeeper rejection. A rebuild is needed after this merges.

## Review follow-up (applied)

A review ran against this PR; findings were addressed in a follow-up commit. All fixes are consumer-side — **shared-workflows is unchanged.**

| Finding | Status |
|---|---|
| Identity grep dropped the Team ID, was position-blind, and used a regex where a fixed string was meant | **Fixed** — full identity, leaf-pinned, `grep -qF` |
| No trust evaluation (`Status:` unread; `stapler` does not check the chain) | **Fixed** — added `spctl --assess --type install` as the gate |
| Ownership check missed the `/usr/local/bin` payload root; tested uid only; could not distinguish its own failure from success | **Fixed** — both roots scanned, mode bits tested, error swallowing removed, non-vacuity asserted |
| Verified pkg was not provably the installed pkg | **Fixed** — resolved once, exact-count asserted, exported as `VERIFIED_PKG` |
| Verification coverage coupled to the test matrix | **Open** — needs a dedicated `verify-mac-signing` job; see below |
| Embedded binaries signed with hardened runtime and no entitlements | **Resolved — not applicable to this repo**; see below |
| Bundle payload assembled from unverified downloads (bundle repo only) | **Open** — pre-existing; needs its own PR |

### Entitlements: checked, not applicable here

Fixing the glob activates the shared signer's embedded-binary codesigning, which runs `codesign --deep --force --options runtime --timestamp --sign` with **no `--entitlements`** (verified: zero occurrences in `entrypoint.sh@v3.7.0`). That is **not a hazard for this repo**, which was the missing check rather than an assumption worth carrying: every dynamic dependency of the shipped `asbench` arm64 binary is an Apple-signed system library or framework (libSystem, libz), with no bundled or third-party dylibs. Library validation always permits those. Confirmed empirically -- re-signed the real CI artifact with `codesign --force --options runtime` and no entitlements (`flags=0x10002(adhoc,runtime)`), and it still runs `--version` and `--help`.

The fix is available consumer-side and is better than an upstream input, because the signer **skips** binaries already signed with the expected identity:

```bash
if [[ -n $current_authority && $current_authority == *"$SIGNING_IDENTITY"* ]]; then
    echo "    Already signed with correct identity, skipping: $rel"
```

So pre-signing embedded binaries in `build-mac-artifacts` with `--entitlements` both preserves the entitlements **and** leaves `signed_any=false`, which skips the `cpio` repack entirely — removing the ownership-downgrade defect at its root instead of detecting it after the fact.

Not implemented here: it requires the Apple Application cert and keychain setup wired into the build job across six repos, and this workflow cannot be executed from a PR (`workflow_dispatch`-only), so it would land untested in six release pipelines. **This PR instead makes that failure fail closed and legible** — every entrypoint must execute after install, with the error naming signing rather than surfacing as a bats failure.

### Also still open

- **Coverage coupling.** Verification runs per test-matrix shard, so adding a build target without a matching test target would still ship that pkg unverified. The fix is a dedicated `verify-mac-signing` job that loops every `*.pkg` and asserts an expected count, with `sign-artifacts` depending on it. Not landed untested.
- **Mutable tag pins.** The four highest-privilege callees are pinned to `@v3.7.0`, a mutable tag, while `actions/checkout` is SHA-pinned. Pre-existing and arguably deliberate policy; if tags are meant to float, the mitigation is tag protection on `aerospike/shared-workflows`.

### Evidence status — unchanged and still the main gap

None of these steps has executed. This workflow is `workflow_dispatch`-only, so every green check here is a linter or scanner. What closes it: one `release=false` dispatch with `artifact-glob` reverted to `**/*.pkg` showing the verify step **red**, and one with the fix showing all assertions **green** on all four mac runners. The ownership predicate now also tests group/world-writable bits, which needs that first run to confirm no legitimate installed file trips it.

What I did verify locally: YAML parses, every `run:` block passes `bash -n`, and the new ownership logic was exercised against a sandbox tree for pass, missing-entrypoint, vacuous-scan, world-writable, and non-executing-entrypoint cases — pass reaches all three assertions and exits 0; each failure case exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



