### PR TITLE
ci: verify rpm/deb GPG signatures before deploy

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -363,6 +363,83 @@ jobs:
       gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}
       gpg-key-pass: ${{ secrets.GPG_PASS }}
 
+  verify-signatures:
+    name: Verify rpm/deb GPG signatures
+    needs: [get-version, sign-artifacts]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Download signed artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: signed-artifacts-${{ needs.get-version.outputs.VERSION }}
+          path: ./packages
+
+      - name: Install verification tools
+        run: sudo apt-get update && sudo apt-get install -y rpm dpkg-sig
+
+      - name: Verify signatures
+        env:
+          GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+        run: |
+          set -euo pipefail
+          # sign-artifacts embeds a signature in every rpm (rpm --addsign) and
+          # deb (dpkg-sig), and drops a detached .asc beside every artifact.
+          # None of that was verified anywhere, so a key expiry, a rotated
+          # secret, or a signer regression would ship silently -- exactly how
+          # the unsigned macOS pkgs got through.
+          printf '%s\n' "${GPG_PUBLIC_KEY}" > /tmp/aerospike-pub.asc
+          gpg --batch --quiet --import /tmp/aerospike-pub.asc
+          sudo rpm --import /tmp/aerospike-pub.asc
+
+          rpm_n=0 deb_n=0 asc_n=0 fail=0
+
+          while IFS= read -r f; do
+            case "$f" in
+            *.rpm)
+              rpm_n=$((rpm_n + 1))
+              if ! sudo rpm --checksig "$f" | grep -q "signatures OK"; then
+                echo "ERROR: rpm signature check failed: $f" >&2
+                sudo rpm --checksig "$f" >&2 || true
+                fail=1
+              fi
+              ;;
+            *.deb)
+              deb_n=$((deb_n + 1))
+              if ! dpkg-sig --verify "$f" | grep -q "GOODSIG"; then
+                echo "ERROR: deb signature check failed: $f" >&2
+                dpkg-sig --verify "$f" >&2 || true
+                fail=1
+              fi
+              ;;
+            esac
+          done < <(find ./packages -type f \( -name "*.rpm" -o -name "*.deb" \) | sort)
+
+          while IFS= read -r sig; do
+            asc_n=$((asc_n + 1))
+            if ! gpg --batch --verify "$sig" "${sig%.asc}" 2>&1 | grep -q "Good signature"; then
+              echo "ERROR: detached signature check failed: $sig" >&2
+              gpg --batch --verify "$sig" "${sig%.asc}" >&2 2>&1 || true
+              fail=1
+            fi
+          done < <(find ./packages -type f -name "*.asc" | sort)
+
+          echo "==> verified rpm=${rpm_n} deb=${deb_n} detached-asc=${asc_n}"
+
+          # Never pass vacuously: the signer produces all three kinds, so all
+          # three must be present and actually checked.
+          [[ ${rpm_n} -gt 0 ]] || { echo "ERROR: no .rpm found to verify" >&2; fail=1; }
+          [[ ${deb_n} -gt 0 ]] || { echo "ERROR: no .deb found to verify" >&2; fail=1; }
+          [[ ${asc_n} -gt 0 ]] || { echo "ERROR: no .asc found to verify" >&2; fail=1; }
+
+          exit "${fail}"
+
   test-install-linux-and-execute:
     name: Test install & execute (${{ matrix.distro }}, ${{ contains(matrix.host, 'arm') && 'arm64' || 'amd64' }})
     needs: [get-version, sign-artifacts]
@@ -501,7 +578,7 @@ jobs:
 
   organize-signed-artifacts:
     name: Organize signed artifacts for deploy
-    needs: [get-version, test-install-linux-and-execute, test-install-mac-and-execute]
+    needs: [get-version, verify-signatures, test-install-linux-and-execute, test-install-mac-and-execute]
     runs-on: ubuntu-24.04
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

**rpm and deb signing works — but nothing verifies it.** This adds that verification and makes it block deploy.

Checked while confirming the macOS signing fix: `sign-artifacts` is healthy in all six tool repos. Every rpm gets an embedded signature (`rpm --addsign`), every deb gets one (`dpkg-sig`), and all 24 artifacts get a detached `.asc`. Zero errors, in every repo:

| Repo | processed | rpm `--addsign` | deb `dpkg-sig` | detached `.asc` | errors |
|---|---|---|---|---|---|
| aerospike-tools | 24 | 8 | 12 | 24 | 0 |
| aerospike-admin | 24 | 8 | 12 | 24 | 0 |
| aerospike-tools-backup | 24 | 8 | 12 | 24 | 0 |
| aql | 24 | 8 | 12 | 24 | 0 |
| asconfig | 24 | 8 | 12 | 24 | 0 |
| aerospike-benchmark | 24 | 8 | 12 | 24 | 0 |

## The gap

There is **not one** `rpm --checksig`, `rpm -K`, `gpg --verify`, `dpkg-sig --verify`, or `debsig-verify` anywhere in any of the six pipelines. The linux test jobs just run:

```bash
apt-get install -y "${pkg}"     # local .deb  -- no GPG validation
dnf install -y "${pkg}"         # local .rpm  -- localpkg_gpgcheck defaults off
```

So signing is **load-bearing and unchecked**. A key expiry, a rotated `GPG_SECRET_KEY`, or a signer regression would ship silently through a green pipeline — precisely how the unsigned macOS pkgs got through six release pipelines undetected.

## What this adds

A `verify-signatures` job that, on the artifact set that actually ships:

- imports `GPG_PUBLIC_KEY` into both the gpg and rpm keyrings
- `rpm --checksig` on every `.rpm`, asserting `signatures OK` (an *unsigned* rpm reports only `digests OK`, so this distinguishes them — merely checking exit status would not)
- `dpkg-sig --verify` on every `.deb`, asserting `GOODSIG`
- `gpg --verify` on every detached `.asc`, asserting `Good signature`

Two design decisions worth reviewing:

**One ubuntu job, not inside the linux test matrix.** Those 10 legs run in minimal distro containers (`redhat/ubi8`, `debian:bullseye`, `amazonlinux`, …) that lack `rpm-sign`/`dpkg-sig`/`gpg`. Verifying there would mean installing tooling into 10 images and maintaining it per-distro. One ubuntu-24.04 job checks the identical artifacts with none of that fragility.

**`organize-signed-artifacts` now `needs: verify-signatures`.** Without that edge the job would run in parallel with the test jobs, so a signature failure would mark the workflow red *while deploy still published*. The new dependency makes it a real gate.

**No vacuous pass.** It asserts `rpm`, `deb`, and `asc` counts are each non-zero, and reports *every* failure rather than stopping at the first. An empty or partial artifact set fails loudly instead of quietly reporting success — the same trap the macOS bug exploited.

## Verification

I cannot run `rpm`/`dpkg-sig` against real signed artifacts locally (macOS host; and those runs' artifacts have expired under `gh-retention-days: 1`). So I validated the control flow against stubs that emulate each tool's real output contract, and re-ran the **script as extracted from the committed YAML** to confirm the block scalar didn't mangle `printf '%s\n'` or `find ... \( ... \)`:

| case | result |
|---|---|
| all signatures good (8 rpm / 12 deb / 24 asc) | `exit=0`, counts correct ✅ |
| one unsigned rpm (`digests OK`) | caught, `exit=1` ✅ |
| one `NOSIG` deb | caught, `exit=1` ✅ |
| one bad detached `.asc` | caught, `exit=1` ✅ |
| no rpm present (vacuous) | caught, `exit=1` ✅ |
| empty artifact dir | all three caught, `exit=1` ✅ |

YAML parses; the `run:` body passes `bash -n`; job wiring and the `needs` gate confirmed by parsing the committed file.

**Not yet proven:** the real `rpm --checksig` / `dpkg-sig --verify` / `gpg --verify` output has not been exercised against genuinely signed Aerospike packages, only against stubs matching their documented output. The string matches (`signatures OK`, `GOODSIG`, `Good signature`) are the load-bearing assumption. **Please run this once on a real release build before merging** — if a match string is off, the job fails closed (red on good packages), which is safe but noisy.

## Related

Follow-up to the macOS signing fix. That PR and this one touch different hunks of the same file and are independent — either can merge first:

- citrusleaf/aerospike-tools#440 · aerospike/aerospike-admin#533 · aerospike/aerospike-tools-backup#170 · aerospike/aql#91 · aerospike/asconfig#134 · aerospike/aerospike-benchmark#161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
