### PR TITLE
TOOLS-4381: --help documents --connection-timeout, but the actual flag is --connect-timeout

### DIFF
--- a/src/main/benchmark_init.c
+++ b/src/main/benchmark_init.c
@@ -615,7 +615,7 @@ print_usage(const char* program)
 	printf("   Causes the benchmark tool to generate data which will roughly compress by this proportion.\n");
 	printf("\n");
 
-	printf("   --connection-timeout <ms> # Default: 1000\n");
+	printf("   --connect-timeout <ms> # Default: 1000\n");
 	printf("   Initial host connection timeout in milliseconds.\n");
 	printf("   The timeout when opening a connection to the server host for the first time.\n");
 	printf("\n");


### PR DESCRIPTION
asbench --help prints:

--connection-timeout <ms> # Default: 1000
Initial host connection timeout in milliseconds.
The timeout when opening a connection to the server host for the first time.

But running with that exact flag name fails:
$ asbench -h 127.0.0.1:3000 --connection-timeout 5000
asbench: unrecognized option '--connection-timeout'

The flag that's actually registered in getopt_long is --connect-timeout (line 124)
while the usage text (line 618) says --connection-timeout instead.