### PR TITLE
feat: alias asbench 2.2.9 and latest on Docker Hub

### DIFF
--- a/.github/workflows/copy-tools-images-to-dockerhub.yml
+++ b/.github/workflows/copy-tools-images-to-dockerhub.yml
@@ -3,7 +3,8 @@ name: Copy aerospike-asbench images to Docker Hub
 # Copies already-published aerospike-asbench tags from JFrog to Docker Hub.
 # Does not build images and does not write anything back to Artifactory.
 # Tags: 2.2.9-3 (multi-arch index), 2.2.9-3-amd64 (linux/amd64),
-# 2.2.9-3-arm64 (linux/arm64).
+# 2.2.9-3-arm64 (linux/arm64). Extra dest tags 2.2.9 and latest
+# are aliases of 2.2.9-3.
 
 on:
   workflow_dispatch:
@@ -25,6 +26,14 @@ on:
         type: boolean
         required: false
         default: true
+      alias-from:
+        description: Source tag to copy onto extra destination tags
+        required: false
+        default: 2.2.9-3
+      alias-tags:
+        description: Extra destination tags (comma-separated) based on alias-from
+        required: false
+        default: 2.2.9,latest
 
 permissions:
   contents: read
@@ -77,6 +86,8 @@ jobs:
           DEST_IMAGE: ${{ inputs.dest-image }}
           TAGS: ${{ inputs.tags }}
           DRY_RUN: ${{ inputs.dry-run }}
+          ALIAS_FROM: ${{ inputs.alias-from }}
+          ALIAS_TAGS: ${{ inputs.alias-tags }}
         run: |
           set -euo pipefail
 
@@ -155,6 +166,59 @@ jobs:
 
             echo "| \`${tag}\` | \`${src_digest}\` | \`${dest_digest}\` |" >> "$GITHUB_STEP_SUMMARY"
           done
+
+          alias_tags_array=()
+          IFS=',' read -ra raw_aliases <<< "${ALIAS_TAGS:-}"
+          for tag in "${raw_aliases[@]}"; do
+            tag="${tag#"${tag%%[![:space:]]*}"}"
+            tag="${tag%"${tag##*[![:space:]]}"}"
+            [ -z "$tag" ] && continue
+            alias_tags_array+=("$tag")
+          done
+
+          if [ "${#alias_tags_array[@]}" -gt 0 ]; then
+            alias_from="${ALIAS_FROM:-}"
+            alias_from="${alias_from#"${alias_from%%[![:space:]]*}"}"
+            alias_from="${alias_from%"${alias_from##*[![:space:]]}"}"
+            if [ -z "$alias_from" ]; then
+              echo "::error::alias-tags was set but alias-from is empty"
+              exit 1
+            fi
+
+            src="${SOURCE_IMAGE}:${alias_from}"
+            echo "::group::Inspect alias source ${src}"
+            docker buildx imagetools inspect "$src"
+            src_digest="$(inspect_digest "$src")"
+            if [ -z "$src_digest" ] || [ "$src_digest" = "null" ]; then
+              echo "::error::could not read digest for $src"
+              exit 1
+            fi
+            echo "source digest: $src_digest"
+            echo "::endgroup::"
+
+            for tag in "${alias_tags_array[@]}"; do
+              dest="${DEST_IMAGE}:${tag}"
+              dest_digest=""
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "dry-run: skipping alias $src -> $dest"
+                dest_digest="(skipped)"
+              else
+                echo "::group::Copy alias ${src} -> ${dest}"
+                copy_tag "$src" "$dest"
+                dest_digest="$(inspect_digest "$dest")"
+                echo "destination digest: $dest_digest"
+                echo "::endgroup::"
+
+                if [ "$src_digest" != "$dest_digest" ]; then
+                  echo "::error::digest mismatch for alias ${tag}: source=${src_digest} dest=${dest_digest}"
+                  exit 1
+                fi
+                copied+=("${dest}@${dest_digest}")
+              fi
+
+              echo "| \`${tag}\` (from \`${alias_from}\`) | \`${src_digest}\` | \`${dest_digest}\` |" >> "$GITHUB_STEP_SUMMARY"
+            done
+          fi
 
           IFS=','
           echo "copied-tags=${copied[*]}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Default the JFrog-to-Hub copy workflow to also publish `2.2.9` and `latest`, matching [aerospike-tools](https://github.com/citrusleaf/aerospike-tools/blob/master/.github/workflows/copy-tools-images-to-dockerhub.yml).
- Those extra dest tags alias the already-published `2.2.9-3` multi-arch index; no rebuild.

## Test plan
- [ ] Dry-run dispatch with the new defaults and confirm the summary lists `2.2.9-3`, `2.2.9-3-amd64`, `2.2.9-3-arm64`, plus aliases `2.2.9` and `latest` from `2.2.9-3`.
- [ ] After merge, dispatch with `dry-run: false` and verify Docker Hub has `aerospike/aerospike-asbench:latest` (and `:2.2.9`) pointing at the same digest as `:2.2.9-3`.