### PR TITLE
ci: TOOLS-3137 - Drop support for Debian 11

### DIFF
--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -4,7 +4,7 @@ set -xeuo pipefail
 function assert_dynamic_deps() {
 	local allowed="libc.so.6 libm.so.6 libpthread.so.0 libdl.so.2 librt.so.1
 		libgcc_s.so.1 libz.so.1 ld-linux-x86-64.so.2 ld-linux-aarch64.so.1"
-	if [ "$ENV_DISTRO" = "el8" ] || [ "$ENV_DISTRO" = "debian11" ]; then
+	if [ "$ENV_DISTRO" = "el8" ]; then
 		allowed+=" libssl.so.1.1 libcrypto.so.1.1"
 	else
 		allowed+=" libssl.so.3 libcrypto.so.3"

--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -25,17 +25,6 @@ function install_libuv() {
 	cd /
 }
 
-function install_deps_debian11() {
-	rm -rf /var/lib/apt/lists/*
-	apt-get clean
-	apt-get update -o Acquire::Retries=5
-	apt-get install -y --no-install-recommends $DEBIAN_DEPS $FPM_DEPS_DEBIAN
-	gem install fpm -v "$FPM_VERSION"
-	install_libuv
-	apt-get clean
-	rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
-}
-
 function install_deps_debian12() {
 	rm -rf /var/lib/apt/lists/*
 	apt-get clean

--- a/.github/packaging/project/install_deps.sh
+++ b/.github/packaging/project/install_deps.sh
@@ -25,17 +25,6 @@ function install_libuv() {
 	cd ..
 }
 
-function install_deps_debian11() {
-	rm -rf /var/lib/apt/lists/*
-	apt-get clean
-	apt-get update -o Acquire::Retries=5
-	apt-get install -y --no-install-recommends $DEBIAN_DEPS $FPM_DEPS_DEBIAN
-	gem install fpm -v 1.17.0
-	install_libuv
-	apt-get clean
-	rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
-}
-
 function install_deps_debian12() {
 	rm -rf /var/lib/apt/lists/*
 	apt-get clean

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -227,7 +227,6 @@ jobs:
           - el9
           - el10
           - amzn2023
-          - debian11
           - debian12
           - debian13
           - ubuntu22.04
@@ -239,7 +238,6 @@ jobs:
         matrix.distro == 'el9' && 'redhat/ubi9:9.6' ||
         matrix.distro == 'el10' && 'redhat/ubi10:10.0' ||
         matrix.distro == 'amzn2023' && 'amazonlinux:2023.9.20251208.0' ||
-        matrix.distro == 'debian11' && 'debian:bullseye-20251208' ||
         matrix.distro == 'debian12' && 'debian:bookworm-20230411' ||
         matrix.distro == 'debian13' && 'debian:trixie-20251020' ||
         matrix.distro == 'ubuntu22.04' && 'ubuntu:jammy-20231004' ||
@@ -520,7 +518,6 @@ jobs:
           - el9
           - el10
           - amzn2023
-          - debian11
           - debian12
           - debian13
           - ubuntu22.04
@@ -532,7 +529,6 @@ jobs:
         matrix.distro == 'el9' && 'redhat/ubi9:9.6' ||
         matrix.distro == 'el10' && 'redhat/ubi10:10.0' ||
         matrix.distro == 'amzn2023' && 'amazonlinux:2023.9.20251208.0' ||
-        matrix.distro == 'debian11' && 'debian:bullseye-20251208' ||
         matrix.distro == 'debian12' && 'debian:bookworm-20230411' ||
         matrix.distro == 'debian13' && 'debian:trixie-20251020' ||
         matrix.distro == 'ubuntu22.04' && 'ubuntu:jammy-20231004' ||


### PR DESCRIPTION
## Why

[TOOLS-3137](https://aerospike.atlassian.net/browse/TOOLS-3137) - "(TOOLS) Remove support for Debian 11":

> After August 31 2026, remove Debian 11 builds from the tools package and all the individual tools.

Debian 11 (bullseye) reached LTS end-of-life on **2026-08-31**, and its `bullseye-security` `Release` file expired on **2026-09-07**. `apt-get update` now fails inside the pinned `debian:bullseye-20251208` container, so every `debian11` job in **Build and Release** dies at *Install prereqs*, before checkout:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired (invalid since 1d 6h 55min 24s). Updates for this repository will not be applied.
/__w/_temp/b518dda2-84cd-4f38-9744-91baf5ea899b.sh: line 12: git: command not found
##[error]Process completed with exit code 127.
```

Representative failure (aql): https://github.com/aerospike/aql/actions/runs/34309755577

Keeping the jobs alive was considered and rejected: pinning `Acquire::Check-Valid-Until=false` gets past the expiry check, but the bullseye pool is already being purged, and a Debian 11 artifact built after EOL would ship against a base that receives no further security updates.

## What changed

- `.github/workflows/build-and-release.yml` - drop `debian11` from the `build-artifacts` and `test-install-linux-and-execute` matrices and remove its container image mapping.
- `.github/bin/install_deps.sh` and `.github/packaging/project/install_deps.sh` - remove `install_deps_debian11` from both.
- `.github/bin/build_package.sh` - drop the `debian11` arm of the OpenSSL 1.1 `DT_NEEDED` allowance. `el8` keeps it.

## Not in this PR

- `.github/bin/os_version.sh` still maps the `bullseye` codename. That is generic host detection rather than matrix config, and the `buster` mapping was likewise left in place when Debian 10 was dropped.
- The `apt-get update && apt-get install ...` one-liner in *Install prereqs* still masks apt failures under `set -e` (bash exempts `&&` lists), which is why the job reported a confusing `git: command not found` instead of the apt error. Worth splitting, but out of scope here.

## Verification

- Both matrices go from 10 distros to 9; no `debian11` entry remains in either.
- Workflow YAML parses.
- `bash -n` clean on every touched shell script.

## Related

Debian 11 removal is already complete everywhere else: TOOLS-3134 (ACT), TOOLS-3135 (ASMT), TOOLS-3136 (ASVALIDATION), CLIENT-3881 (C/C++), CLIENT-3882 (Python), CLIENT-3883 (Node.js), AER-6854, REL-3931, REL-3932, DOCS-3794, DOCS-3901, QE-581, QE-592, and the NEW download listings. TOOLS-3137 is the last open ticket.

Companion PRs on the same branch name (`TOOLS-3137-drop-debian11`) in: aql, aerospike-admin, aerospike-tools-backup, aerospike-benchmark, asconfig, aerospike-tools.


[TOOLS-3137]: https://aerospike.atlassian.net/browse/TOOLS-3137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ