### PR TITLE
build(docker): base the asbench image on ubuntu:24.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,9 +9,10 @@
 # SHA256s as build args (and optionally an in-context .deb via ASBENCH_LOCAL_PKG*).
 # Build directly only if you set those args yourself; otherwise use the script.
 #
-# Base: debian:trixie-slim. The .deb is built on Ubuntu 24.04; trixie ships a
-# recent glibc and common C libs the binary may dynamically link to — apt
-# installs the .deb and anything it (transitively) needs.
+# Base: ubuntu:24.04, the distro the .deb is built on, so its Depends resolve
+# against the packages they were compiled against. It is also the base the
+# legacy aerospike-tools image used and the one aerospike-server.docker
+# publishes — apt installs the .deb and anything it (transitively) needs.
 #
 
 ARG ASBENCH_AMD64_URL=""
@@ -19,7 +20,7 @@ ARG ASBENCH_AMD64_SHA256=""
 ARG ASBENCH_ARM64_URL=""
 ARG ASBENCH_ARM64_SHA256=""
 
-FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8
+FROM ubuntu:24.04@sha256:224a1869083a311ef3f13648a154ba79832fbef6364d31493642ca03082da254
 
 ARG ASBENCH_AMD64_URL
 ARG ASBENCH_AMD64_SHA256
@@ -32,7 +33,7 @@ ARG ASBENCH_LOCAL_PKG_ARM64=""
 LABEL org.opencontainers.image.title="Aerospike asbench" \
       org.opencontainers.image.description="asbench, a benchmarking tool for Aerospike database." \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-benchmark" \
-      org.opencontainers.image.base.name="docker.io/library/debian:trixie-slim" \
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.vendor="Aerospike"
 


### PR DESCRIPTION
## Problem

This image is built `FROM debian:trixie-slim` while the `.deb` it installs is built on Ubuntu 24.04. The image it sits alongside, the legacy [aerospike-tools.docker](https://github.com/aerospike/aerospike-tools.docker) one (last tagged `13.0.2_1`), was built `FROM ubuntu:24.04`, and `aerospike-server.docker` publishes its primary images on `ubuntu:24.04`.

Users who layer their own `apt-get install` on our image, or script against the base, hit a distro they did not expect: different apt sources, different package names (`libreadline8t64` vs `libreadline8`), different `/etc/os-release`.

## Change

`docker/Dockerfile` only:

- `FROM ubuntu:24.04@sha256:224a1869083a311ef3f13648a154ba79832fbef6364d31493642ca03082da254` (digest-pinned, as the debian base was).
- `org.opencontainers.image.base.name` label -> `docker.io/library/ubuntu:24.04`.
- Header comment rewritten to say why.

No change to package selection: `docker/docker-build.sh` already resolves the `...ubuntu24.04_<arch>.deb` from the `noble` pool, so the package now installs on the distro it was built for.

glibc is the one hard constraint here (asadm's PyInstaller bundle needs `GLIBC_2.38`; bookworm's 2.36 is why trixie was picked over it). Noble ships 2.39.

## Verification

Verified end-to-end on the bundle image, which carries this same binary from the same build: built `FROM ubuntu:24.04` against the released 13.0.3-5 `ubuntu24.04` bundle package on arm64, apt resolved every `Depends` from the ubuntu repos with no unmet-dependency warnings, and every entrypoint ran (`aql`, `asadm`, `asinfo`, `asbackup`, `asrestore`, `asbench`, `asconfig`, all `--version`). Image came out slightly smaller than the debian one (101.3 MB vs 105.8 MB) despite ubuntu:24.04 not being a `-slim` variant.

This repo's own image is built by the release workflow, not by PR CI, so the per-tool build runs at the next release.

## Companion PRs

- https://github.com/citrusleaf/aerospike-tools/pull/455 (bundle image; also moves package selection from the debian13 .deb to the ubuntu24.04 one)
- https://github.com/aerospike/aql/pull/105 (aql image)
- https://github.com/aerospike/aerospike-admin/pull/556 (asadm image)
- https://github.com/aerospike/asconfig/pull/146 (asconfig image)
- https://github.com/aerospike/aerospike-tools-backup/pull/181 (asbackup image)

TOOLS-4399
