### PR TITLE
feat(ci): TOOLS-4364 build docker images via shared-workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# docker/Dockerfile builds with the repo root as its context so CI can drop the
+# signed .deb at deploy-artifacts/ (see the docker-build job). The image reads
+# that one path and nothing else, so everything else is excluded -- otherwise
+# every build leg uploads the whole working tree, .git included.
+# Re-include here anything a future COPY or bind-mount read needs: an excluded
+# path is simply absent from the context, which the Dockerfile reports as
+# "not in the build context" for the .deb and would silently miss elsewhere.
+*
+!deploy-artifacts

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -178,6 +178,8 @@ jobs:
       VERSION: ${{ steps.compute.outputs.version }}
       BUILD_VERSION: ${{ steps.compute.outputs.build_version }}
       RELEASE: ${{ steps.release.outputs.RELEASE }}
+      DEB_AMD64: ${{ steps.deb-name.outputs.amd64 }}
+      DEB_ARM64: ${{ steps.deb-name.outputs.arm64 }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -216,6 +218,23 @@ jobs:
           set -euo pipefail
           .github/bin/pkg_release.sh "${BUILD_VERSION}" all | tee -a "$GITHUB_OUTPUT"
 
+      # The name pkg/Makefile gives the .deb the docker image installs, emitted
+      # once here because docker-verify builds the image and docker-build
+      # publishes it -- deriving it twice is how the two drift apart. Format is
+      # <name>_<pkg-version>-<iteration><distro>_<dpkg-arch>.deb. ubuntu24.04 of
+      # all the distro builds: the image is based on ubuntu:24.04, the distro
+      # that build's bundled libraries were linked against (docker/Dockerfile).
+      - name: Derive the .deb names the docker image installs
+        id: deb-name
+        env:
+          RELEASE: ${{ steps.release.outputs.RELEASE }}
+        run: |
+          set -euo pipefail
+          [[ -n "${RELEASE}" ]] || { echo "ERROR: empty RELEASE" >&2; exit 1; }
+          for arch in amd64 arm64; do
+            echo "${arch}=aerospike-asbench_${RELEASE}ubuntu24.04_${arch}.deb"
+          done | tee -a "$GITHUB_OUTPUT"
+
   build-artifacts:
     needs: get-version
     strategy:
@@ -245,6 +264,7 @@ jobs:
         matrix.distro == 'ubuntu26.04' && 'ubuntu:resolute-20260413' }}
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -296,6 +316,48 @@ jobs:
           set -euo pipefail
           source .github/bin/build_package.sh
           build_packages
+
+      # Per-leg build-info: the environment and git revision each package was
+      # built from. upload-artifacts-to-jfrog discovers these as children of
+      # the release build-info through its jf-metadata-build-id prefix, so the
+      # ID below must keep that prefix.
+      #
+      # Every part of this is best-effort, deliberately unlike the hard-failing
+      # publish in shared-workflows' execute-build entrypoint: it runs once per
+      # distro container per arch, and metadata about a package that
+      # built, signed and tested clean is not worth failing a release over.
+      # A leg that fails here still ships; it just goes missing from the
+      # aggregated build-info, and says so as a warning.
+      - name: Install JFrog CLI
+        if: inputs.release == true
+        continue-on-error: true
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: https://artifact.aerospike.io
+          JF_PROJECT: database
+        with:
+          version: 2.78.8
+          oidc-provider-name: database-gh-aerospike
+          oidc-audience: database-gh-aerospike
+
+      - name: Publish build-info
+        if: inputs.release == true
+        env:
+          JF_BUILD_NAME: aerospike-asbench
+          JF_BUILD_ID: ${{ needs.get-version.outputs.VERSION }}-metadata-${{ matrix.distro }}-${{ contains(matrix.host, 'arm') && 'aarch64' || 'x86_64' }}
+        run: |
+          set -euo pipefail
+          # Guarded because the step above is allowed to fail.
+          if ! command -v jf >/dev/null; then
+            echo "::warning::JFrog CLI unavailable, skipping build-info for ${JF_BUILD_ID}"
+            exit 0
+          fi
+          jf rt build-collect-env "$JF_BUILD_NAME" "$JF_BUILD_ID" --project=database \
+            || echo "::warning::build-collect-env failed for ${JF_BUILD_ID}"
+          jf rt build-add-git "$JF_BUILD_NAME" "$JF_BUILD_ID" --project=database \
+            || echo "::warning::build-add-git failed for ${JF_BUILD_ID}"
+          jf rt build-publish "$JF_BUILD_NAME" "$JF_BUILD_ID" --project=database \
+            || echo "::warning::build-publish failed for ${JF_BUILD_ID}"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -867,6 +929,52 @@ jobs:
           path: deploy-artifacts/
           retention-days: 1
 
+  # Provenance is bound to what actually ships, so it runs after signing:
+  # signing rewrites the deb/rpm in place, and an attestation of the unsigned
+  # digest would never verify against the file a customer downloads.
+  attest-artifacts:
+    name: Attest build provenance
+    if: inputs.release == true
+    needs:
+      - get-version
+      - organize-signed-artifacts
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Download deploy artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: deploy-artifacts-${{ needs.get-version.outputs.VERSION }}
+          path: deploy-artifacts
+
+      - name: Stage installable packages
+        run: |
+          set -euo pipefail
+          # Detached signatures and checksums describe a package rather than
+          # being build outputs of their own, so they get no provenance.
+          mkdir -p attest
+          find deploy-artifacts/ -maxdepth 1 -type f \( \
+            -name '*.deb' -o -name '*.rpm' -o -name '*.tgz' -o \
+            -name '*.tar' -o -name '*.pkg' -o -name '*.exe' \
+          \) -exec cp -t attest/ {} +
+          count=$(find attest/ -maxdepth 1 -type f | wc -l)
+          echo "Attesting ${count} package(s)"
+          ls -la attest/
+          [[ ${count} -gt 0 ]] || { echo "ERROR: no packages to attest" >&2; exit 1; }
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: attest/*
+
   upload-artifacts-to-jfrog:
     needs:
       - get-version
@@ -885,8 +993,16 @@ jobs:
       jf-metadata-build-id: ${{ needs.get-version.outputs.VERSION }}-metadata
       gh-workflows-ref: "v3.7.0"
 
-  docker-build-arch:
-    name: Docker build, test & push (${{ matrix.arch }})
+  # Pre-publish gate. reusable_docker-build-deploy pushes from inside its build
+  # leg and offers no test hook, so once it runs there is no point at which a
+  # broken image has not already reached dev-local under a moving tag. This
+  # builds the same image the same way, exercises it, and publishes nothing --
+  # docker-build needs it, so nothing is pushed until it passes.
+  #
+  # Unconditional, unlike docker-build's push and docker-test: a dry run has to
+  # exercise the image, and this is the only job that can.
+  docker-verify:
+    name: Docker build & smoke test (${{ matrix.arch }})
     needs: [get-version, organize-signed-artifacts]
     strategy:
       fail-fast: false
@@ -897,7 +1013,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -907,6 +1022,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Same artifact and same in-context path docker-build hands the shared
+      # workflow through gh-context-artifacts-json, so this builds from the
+      # bytes that will be published, not a rebuild of them.
       - name: Download deploy artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -914,50 +1032,34 @@ jobs:
           path: ./deploy-artifacts
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: step-security/setup-buildx-action@f931205d68723ad9589fd2a7e2ece238bf9de341 # v4.0.0
 
       - name: Install Snyk CLI
         run: npm install -g snyk@1.1304.3
 
-      - name: Install JFrog CLI
-        if: inputs.release == true
-        id: jf
-        uses: step-security/setup-jfrog-cli@893a92f96c7727242adf0e603c77b1f2a22390e1 # v4.9.1
+      - name: Build the image (no push)
         env:
-          JF_URL: https://artifact.aerospike.io
-          JF_PROJECT: database
-        with:
-          version: 2.78.8
-          oidc-provider-name: database-gh-aerospike
-          oidc-audience: database-gh-aerospike
+          DEB_AMD64: ${{ needs.get-version.outputs.DEB_AMD64 }}
+          DEB_ARM64: ${{ needs.get-version.outputs.DEB_ARM64 }}
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform linux/${{ matrix.arch }} \
+            --file docker/Dockerfile \
+            --build-arg ASBENCH_LOCAL_PKG_AMD64="deploy-artifacts/${DEB_AMD64}" \
+            --build-arg ASBENCH_LOCAL_PKG_ARM64="deploy-artifacts/${DEB_ARM64}" \
+            --load -t asbench-verify:${{ matrix.arch }} .
 
-      - name: Docker login to Artifactory
-        if: inputs.release == true
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: artifact.aerospike.io
-          username: ${{ steps.jf.outputs.oidc-user }}
-          password: ${{ steps.jf.outputs.oidc-token }}
-
-      - name: Build (native) and smoke test
+      - name: Smoke test
         env:
-          VERSION: ${{ needs.get-version.outputs.VERSION }}
+          IMAGE: asbench-verify:${{ matrix.arch }}
           BUILD_VERSION: ${{ needs.get-version.outputs.BUILD_VERSION }}
-          RELEASE: ${{ needs.get-version.outputs.RELEASE }}
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
           set -euo pipefail
-          # docker-build.sh folds the rcN in BUILD_VERSION into the iteration,
-          # so image tags carry <version>-<iteration>, never "rc2".
-          docker/docker-build.sh -t \
-            -v "${BUILD_VERSION}" \
-            -a ${{ matrix.arch }} \
-            -u ../deploy-artifacts
-
-          # Reuse the linux-install bats smoke test against the loaded image
-          # by shimming `asbench` to `docker run` calls.
+          # Reuse the linux-install bats smoke test against the image by
+          # shimming the tool binaries to `docker run` calls.
           sudo apt-get update -qq && sudo apt-get install -y bats
-          IMAGE="aerospike/aerospike-asbench:${RELEASE}-${{ matrix.arch }}"
           SHIM_DIR=$(mktemp -d)
           cat > "${SHIM_DIR}/asbench" <<EOF
           #!/bin/sh
@@ -965,6 +1067,13 @@ jobs:
           EOF
           chmod +x "${SHIM_DIR}/asbench"
           PATH="${SHIM_DIR}:${PATH}" EXPECTED_VERSION="${BUILD_VERSION}" bats .github/bin/test/test_execute.bats
+
+          # Catches a mis-tagged or stale-cached image that the shimmed bats
+          # run cannot see. Same assertion the bats suite uses -- the tool
+          # splits the version across "Version"/"Build" lines, so a substring
+          # match on BUILD_VERSION would never hold.
+          source .github/bin/test/version_lib.sh
+          assert_version_output "$(docker run --rm "${IMAGE}" asbench --version)" "${BUILD_VERSION}"
 
           # The pre-13.0.3 wrapper exported LC_CTYPE=C.UTF-8; the Dockerfile now
           # sets it as ENV. Assert glibc resolves a UTF-8 charmap in the image.
@@ -987,24 +1096,77 @@ jobs:
               --file=docker/Dockerfile || true
           fi
 
-      - name: Push native per-arch tag to JFrog
-        if: inputs.release == true
-        env:
-          VERSION: ${{ needs.get-version.outputs.VERSION }}
-          BUILD_VERSION: ${{ needs.get-version.outputs.BUILD_VERSION }}
-        run: |
-          set -euo pipefail
-          docker/docker-build.sh -p \
-            -v "${BUILD_VERSION}" \
-            -a ${{ matrix.arch }} \
-            -r artifact.aerospike.io/database-docker-dev-local \
-            -u ../deploy-artifacts
+  # Image build/publish/attest is delegated to shared-workflows: it builds each
+  # platform on a native runner, pushes by digest, stitches one manifest list,
+  # publishes the docker build-info and attests the index. docker-build.sh is
+  # still the local/manual path; CI no longer drives it.
+  #
+  # v4.1.0 is the current shared-workflows release and is pinned ahead of the
+  # v3.7.0 used elsewhere in this file because gh-context-artifacts-json --
+  # which puts the signed .deb inside the build context -- only exists from
+  # v4.1.0. Without it the image could only install a package downloaded from
+  # a URL, i.e. not the artifact this run just signed.
+  docker-build:
+    name: Docker build & publish
+    needs: [get-version, organize-signed-artifacts, docker-verify]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    uses: aerospike/shared-workflows/.github/workflows/reusable_docker-build-deploy.yaml@v4.1.0
+    with:
+      # RELEASE, not BUILD_VERSION: on a release BUILD_VERSION is the raw
+      # VERSION file value, rcN included, and app-version feeds the immutable
+      # <app-version>_<timestamp> tag that is always emitted. Passing it would
+      # tag <version>-rcN_<ts> and break the invariant stated at the top of
+      # this file and in pkg_release.sh -- rcN belongs in the package
+      # iteration, never in a file name or image tag.
+      app-version: ${{ needs.get-version.outputs.RELEASE }}
+      app-name: Aerospike asbench
+      image-name: aerospike-asbench
+      jf-project: database
+      jf-build-name: aerospike-asbench-docker
+      repo-scope: -docker-dev-local
+      oidc-provider-name: database-gh-aerospike
+      oidc-audience: database-gh-aerospike
+      context: .
+      file: docker/Dockerfile
+      platforms: linux/amd64,linux/arm64
+      # Still runs on a dry run, publishing nothing. The image itself is
+      # already covered by docker-verify; what only this exercises is the
+      # shared-workflow wiring -- gh-context-artifacts-json placement and
+      # build-args-json parsing -- which would otherwise be first tried
+      # during a real release.
+      push: ${{ inputs.release == true }}
+      # At v4.1.0 the default tag set is <RELEASE>, the bare major, and
+      # "latest"; neither of the last two may move on an rc build, so this
+      # pins the set to exactly <RELEASE>. shared-workflows after v4.1.0
+      # (INFRA-727) drops latest/major from the default, which makes this
+      # belt-and-braces rather than load-bearing -- keep it through that bump.
+      versions-override: ${{ needs.get-version.outputs.RELEASE }}
+      gh-context-artifacts-json: '[{"name": "deploy-artifacts-${{ needs.get-version.outputs.VERSION }}", "dest": "deploy-artifacts"}]'
+      # The Dockerfile installs this path from the build context instead of
+      # downloading a release URL. Names come from get-version so docker-verify
+      # builds and this publishes the same file.
+      build-args-json: '{"ASBENCH_LOCAL_PKG_AMD64": "deploy-artifacts/${{ needs.get-version.outputs.DEB_AMD64 }}", "ASBENCH_LOCAL_PKG_ARM64": "deploy-artifacts/${{ needs.get-version.outputs.DEB_ARM64 }}"}'
 
-  docker-manifest:
-    name: Docker multi-arch manifest (stitch native tags)
+  # Post-publish confirmation, not the gate -- docker-verify already exercised
+  # this image before anything was pushed. What is only checkable after the
+  # fact is the part the shared workflow owns: that the manifest list it
+  # stitched resolves, and that each arch pulls and runs from the index digest
+  # that was attested. Each arch is pulled on its own native runner.
+  docker-test:
+    name: Docker published-image check (${{ matrix.arch }})
     if: inputs.release == true
-    needs: [get-version, docker-build-arch]
-    runs-on: ubuntu-24.04
+    needs: [get-version, docker-build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-24.04,     arch: amd64 }
+          - { runner: ubuntu-24.04-arm, arch: arm64 }
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       id-token: write
@@ -1019,7 +1181,7 @@ jobs:
 
       - name: Install JFrog CLI
         id: jf
-        uses: step-security/setup-jfrog-cli@893a92f96c7727242adf0e603c77b1f2a22390e1 # v4.9.1
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
         env:
           JF_URL: https://artifact.aerospike.io
           JF_PROJECT: database
@@ -1035,46 +1197,25 @@ jobs:
           username: ${{ steps.jf.outputs.oidc-user }}
           password: ${{ steps.jf.outputs.oidc-token }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Stitch per-arch tags into multi-arch manifest
+      - name: Check the published image
         env:
-          VERSION: ${{ needs.get-version.outputs.VERSION }}
+          IMAGE: ${{ needs.docker-build.outputs.image-ref }}
           BUILD_VERSION: ${{ needs.get-version.outputs.BUILD_VERSION }}
         run: |
           set -euo pipefail
-          docker/docker-build.sh -M \
-            -v "${BUILD_VERSION}" \
-            -r artifact.aerospike.io/database-docker-dev-local
+          [[ -n "${IMAGE}" ]] || { echo "ERROR: docker-build produced no image-ref" >&2; exit 1; }
+          docker pull "${IMAGE}"
 
-      # Without build-info the images are invisible to the release bundle, so
-      # `jf rbp` would promote the packages to TEST and leave the images in
-      # dev-local forever.
-      - name: Publish docker build-info
-        env:
-          VERSION: ${{ needs.get-version.outputs.VERSION }}
-          RELEASE: ${{ needs.get-version.outputs.RELEASE }}
-          IMAGE: artifact.aerospike.io/database-docker-dev-local/aerospike-asbench
-          BUILD_NAME: aerospike-asbench-docker
-        run: |
-          set -euo pipefail
-          # Image tags use RELEASE; the build-info build number stays VERSION so
-          # it keeps matching the release bundle's jf-build-names.
-          for tag in "${RELEASE}" "${RELEASE}-amd64" "${RELEASE}-arm64"; do
-            digest=$(docker buildx imagetools inspect "${IMAGE}:${tag}" --format '{{json .Manifest}}' | jq -r '.digest')
-            [[ -n "${digest}" && "${digest}" != "null" ]] \
-              || { echo "::error::no digest for ${IMAGE}:${tag}" >&2; exit 1; }
-            # build-docker-create takes exactly one image ref per invocation.
-            printf '%s:%s@%s\n' "${IMAGE}" "${tag}" "${digest}" > image.txt
-            cat image.txt
-            jf rt build-docker-create database-docker-dev-local \
-              --image-file image.txt \
-              --build-name "${BUILD_NAME}" \
-              --build-number "${VERSION}" \
-              --project database
-          done
-          jf rt build-publish "${BUILD_NAME}" "${VERSION}" --project database
+          # Confirm the index really resolved to this leg's arch, so an arm64
+          # failure can never be masked by silently checking the amd64 manifest.
+          got=$(docker image inspect "${IMAGE}" --format '{{.Architecture}}')
+          [[ "${got}" == "${{ matrix.arch }}" ]] \
+            || { echo "ERROR: pulled ${got} image on ${{ matrix.arch }} runner" >&2; exit 1; }
+
+          # Behaviour is docker-verify's job; this only has to prove the
+          # manifest that got published is the build that passed there.
+          source .github/bin/test/version_lib.sh
+          assert_version_output "$(docker run --rm "${IMAGE}" asbench --version)" "${BUILD_VERSION}"
 
   # Release bundles are JFrog's promotion unit; produced on every publish
   # regardless of branch or skip_tagging.
@@ -1086,12 +1227,18 @@ jobs:
       attestations: write
     needs:
       - get-version
+      - attest-artifacts
       - upload-artifacts-to-jfrog
-      - docker-manifest
+      - docker-build
+      - docker-test
     uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.7.0
     with:
       jf-project: "database"
-      jf-build-names: "aerospike-asbench:${{ needs.get-version.outputs.VERSION }},aerospike-asbench-docker:${{ needs.get-version.outputs.VERSION }}"
+      # The package build-info is still published under VERSION by
+      # upload-artifacts-to-jfrog, but reusable_docker-build-deploy records the
+      # image build-info under the JFrog CLI default build number
+      # (github.run_number). The two names are versioned differently on purpose.
+      jf-build-names: "aerospike-asbench:${{ needs.get-version.outputs.VERSION }},aerospike-asbench-docker:${{ github.run_number }}"
       jf-bundle-name: "aerospike-asbench"
       oidc-provider-name: database-gh-aerospike
       oidc-audience: database-gh-aerospike
@@ -1109,8 +1256,10 @@ jobs:
     needs:
       - validate-inputs
       - get-version
+      - attest-artifacts
       - upload-artifacts-to-jfrog
-      - docker-manifest
+      - docker-build
+      - docker-test
       - create-release-bundle
     runs-on: ubuntu-24.04
     environment: deploy-to-main
@@ -1158,7 +1307,7 @@ jobs:
           egress-policy: audit
 
       - name: Setup JFrog CLI
-        uses: step-security/setup-jfrog-cli@893a92f96c7727242adf0e603c77b1f2a22390e1 # v4.9.1
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
         env:
           JF_URL: https://artifact.aerospike.io
           JF_PROJECT: database

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,13 @@ RUN --mount=type=bind,source=.,target=/build-ctx \
         LOCAL_PKG="${ASBENCH_LOCAL_PKG_ARM64:-${ASBENCH_LOCAL_PKG}}"; \
     fi && \
     apt-get update -y && \
-    if [ -n "${LOCAL_PKG}" ] && [ -f "/build-ctx/${LOCAL_PKG}" ]; then \
+    if [ -n "${LOCAL_PKG}" ]; then \
+        if [ ! -f "/build-ctx/${LOCAL_PKG}" ]; then \
+            echo "ERROR: ${LOCAL_PKG} not in the build context." >&2; \
+            echo "Available .deb: $(find /build-ctx -name '*.deb' -printf '%P ' 2>/dev/null)" >&2; \
+            echo "The name is derived by the caller from pkg_release.sh; fix the derivation rather than falling back to an unverified download." >&2; \
+            exit 1; \
+        fi; \
         cp "/build-ctx/${LOCAL_PKG}" /tmp/asbench.deb; \
     else \
         apt-get install -y --no-install-recommends curl ca-certificates && \


### PR DESCRIPTION
Ports the docker CI rework from aerospike-admin (aerospike/aerospike-admin#552) so all six tools repos share one pipeline shape.

## What changes

`docker-build-arch` + `docker-manifest` are replaced by three jobs:

| job | when | what it does |
|---|---|---|
| `docker-verify` | every dispatch | Builds each platform natively from the signed `.deb` and smoke-tests it. Publishes nothing. |
| `docker-build`  | every dispatch, pushes only on release | Delegates build / push / manifest / build-info / attest to `reusable_docker-build-deploy@v4.1.0`. |
| `docker-test`   | release only | Pulls the published index on each arch and confirms it is the build that passed `docker-verify`. |

`docker-verify` gates `docker-build`, so a broken image can no longer reach dev-local: the shared workflow pushes from inside its own build leg and offers no test hook, which is why the gate has to be a separate job.

Also in this PR:

- **Per-leg JFrog build-info** in `build-artifacts` (environment + git revision per distro/arch). Best-effort: a leg that fails here still ships, and warns.
- **`attest-artifacts`**: SLSA provenance for the signed packages. Runs after signing, because signing rewrites the deb/rpm in place and an attestation of the unsigned digest would never verify.
- **`.dockerignore`**: the build context carries only `deploy-artifacts`, instead of the whole working tree including `.git`.
- **Dockerfile**: fails loudly when the named `.deb` is missing from the build context, rather than silently falling back to an unverified download.
- **`setup-jfrog-cli` bumped to v5.1.0** (Node 24 runtime).

## Breaking: per-arch image tags go away

`reusable_docker-build-deploy` pushes each platform *by digest* and tags only the manifest list, so `<release>-amd64` and `<release>-arm64` are no longer published. Docker Hub keeps the multi-arch index and its aliases; only the per-arch tags are dropped.

Updating `copy-tools-images-to-dockerhub.yml` to stop defaulting to those tags is a **companion PR** on `TOOLS-4364-dockerhub-tags`, kept separate so this PR touches only the build pipeline. The two should land together: merge this one alone and the copy workflow still defaults to tags that no longer exist.

## Notes

- Pinned to `v4.1.0`, the current shared-workflows release. `gh-context-artifacts-json`, which puts the signed `.deb` inside the build context, only exists from v4.1.0; without it the image could only install a package downloaded from a URL rather than the artifact the run just signed.
- `versions-override` is passed to keep `latest` and the bare major from moving on an rc build. shared-workflows after v4.1.0 (INFRA-727) drops those from the default tag set, at which point the override becomes belt-and-braces; it is kept so the bump is a no-op.
- `jf-build-names` versions the docker build-info by `github.run_number` and the package build-info by `VERSION`, on purpose: the shared workflow records images under the JFrog CLI default build number. This matches the reference `example_docker-test.yaml`.

## Verification

- `actionlint` clean; finding counts compared against each repo's baseline, so nothing new was introduced.
- Job graph and every shared step diffed against the other five repos after normalizing tool/package/OIDC names: `docker-build` and `attest-artifacts` are byte-identical across all six. `docker-verify` and `docker-test` differ only in which binaries get asserted and whether `astools.conf` is checked, which tracks real product differences.
